### PR TITLE
Update Fedora dependencies to install xprop and xwininfo

### DIFF
--- a/scripts/install_matrix.json
+++ b/scripts/install_matrix.json
@@ -40,7 +40,7 @@
       "packages": {
         "core": ["python3", "python3-pip", "python3-virtualenv", "rsync", "curl"],
         "qt": ["libxkbcommon", "libxkbcommon-x11", "xcb-util-cursor"],
-        "wayland": ["wmctrl", "xorg-x11-utils"]
+        "wayland": ["wmctrl", "xwininfo", "xprop"]
       }
     },
     {


### PR DESCRIPTION
These two dependencies are in their own separate packages, at least from F42 and up.
