### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/inno_prototype.yml
+++ b/.github/workflows/inno_prototype.yml
@@ -1,4 +1,6 @@
 name: Inno Installer Prototype
+permissions:
+  contents: read
 
 on:
   workflow_dispatch: {}


### PR DESCRIPTION
Potential fix for [https://github.com/SweetJonnySauce/EDMCModernOverlay/security/code-scanning/4](https://github.com/SweetJonnySauce/EDMCModernOverlay/security/code-scanning/4)

To fix the problem, explicitly add a `permissions` block to the workflow (or, alternatively, to the job itself). The minimal recommended permission for this workflow is `contents: read`, since the actions only read from the repository and upload artifacts, and do not interact with issues, pull-requests, or other APIs that require write access. You should insert:

```yaml
permissions:
  contents: read
```

You may place this at the top of the workflow (global/workflow-level), before `jobs:`, to apply to every job. Alternatively, you can put it into the `build` job, but workflow-level is sufficient and preferred for clarity.

**Required steps:**  
- Edit `.github/workflows/inno_prototype.yml`
- Insert the `permissions` block after the workflow `name` and before `on:` (recommended), or as the first entry under the `build:` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
