### PR TITLE
initial implementation of controller-last-visible-box

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,8 +11,9 @@
 - Bug Fixes
   - Fixes [#42](https://github.com/SweetJonnySauce/EDMCModernOverlay/issues/42) and [#43](https://github.com/SweetJonnySauce/EDMCModernOverlay/issues/43). Address nuanced backwards compatibility issues for vector images and marker labels that mainly affected EDR Navigation.
   - Fixed [#21](https://github.com/SweetJonnySauce/EDMCModernOverlay/issues/21). EDR Help and Docking payloads were not clearing when EDR sent the clear message. Modified the shim layer to allow positional arguments (see [#13](https://github.com/SweetJonnySauce/EDMCModernOverlay/issues/13))
-  - Fixed [#46](https://github.com/SweetJonnySauce/EDMCModernOverlay/issues/43). Fedora install now checks to see if the `flatpak-spawn` package is installed. (Fedora packages it separately.)
+  - Fixed [#46](https://github.com/SweetJonnySauce/EDMCModernOverlay/issues/46). Fedora install now checks to see if the `flatpak-spawn` package is installed. (Fedora packages it separately.)
   - Tweaked some preference settings for a more consistent UI/UX.
+  - Fixed [#48](https://github.com/SweetJonnySauce/EDMCModernOverlay/issues/48). A "pinned" group in the overlay controller is when it's nudged up next to the edge. The arrow in the controller stays orange when pinned. This fix was to address a problem where pinning did not reset when the plugin group changed in the controller.
   
 ## 0.7.5
 - Features & Improvements:

--- a/debug.json
+++ b/debug.json
@@ -1,8 +1,10 @@
 {
-  "capture_client_stderrout": false,
+  "capture_client_stderrout": true,
   "overlay_logs_to_keep": 5,
   "payload_logging": {
-    "exclude_plugins": [],
-    "overlay_payload_log_enabled": false
+    "exclude_plugins": [
+      "bgs-tally"
+    ],
+    "overlay_payload_log_enabled": true
   }
 }

--- a/docs/refactoring/controller-last-visible-box.md
+++ b/docs/refactoring/controller-last-visible-box.md
@@ -1,0 +1,235 @@
+## Goal: Controller Target Box Persistence (Last vs Max)
+
+## Refactorer Persona
+- Bias toward carving out modules aggressively while guarding behavior: no feature changes, no silent regressions.
+- Prefer pure/push-down seams, explicit interfaces, and fast feedback loops (tests + dev-mode toggles) before deleting code from the monolith.
+- Treat risky edges (I/O, timers, sockets, UI focus) as contract-driven: write down invariants, probe with tests, and keep escape hatches to revert quickly.
+- Default to “lift then prove” refactors: move code intact behind an API, add coverage, then trim/reshape once behavior is anchored.
+- Resolve the “be aggressive” vs. “keep changes small” tension by staging extractions: lift intact, add tests, then slim in follow-ups so each step stays behavior-scoped and reversible.
+- Track progress with per-phase tables of stages (stage #, description, status). Mark each stage as completed when done; when all stages in a phase are complete, flip the phase status to “Completed.” Number stages as `<phase>.<stage>` (e.g., 1.1, 1.2) to keep ordering clear.
+- Personal rule: if asked to “Implement…”, expand/document the plan and stages (including tests to run) before touching code.
+- Personal rule: keep notes ordered by phase, then by stage within that phase.
+
+## Dev Best Practices
+
+- Keep changes small and behavior-scoped; prefer feature flags/dev-mode toggles for risky tweaks.
+- Plan before coding: note touch points, expected unchanged behavior, and tests you’ll run.
+- Avoid UI work off the main thread; keep new helpers pure/data-only where possible.
+- Record tests run (or skipped with reasons) when landing changes; default to headless tests for pure helpers.
+- Prefer fast/no-op paths in release builds; keep debug logging/dev overlays gated behind dev mode.
+
+## Per-Iteration Test Plan
+- **Env setup (once per machine):** `python3 -m venv .venv && source .venv/bin/activate && pip install -U pip && pip install -e .[dev]`
+- **Headless quick pass (default for each step):** `source .venv/bin/activate && python -m pytest` (scope with `tests/…` or `-k` as needed).
+- **Core project checks:** `make check` (lint/typecheck/pytest defaults) and `make test` (project test target) from repo root.
+- **Full suite with GUI deps (as applicable):** ensure GUI/runtime deps are installed (e.g., PyQt for Qt projects), then set the required env flag (e.g., `PYQT_TESTS=1`) and run the full suite.
+- **Targeted filters:** use `-k` to scope to touched areas; document skips (e.g., long-running/system tests) with reasons.
+- **After wiring changes:** rerun headless tests plus the full GUI-enabled suite once per milestone to catch integration regressions.
+
+## Guiding Traits for Readable, Maintainable Code
+- Clarity first: simple, direct logic; avoid clever tricks; prefer small functions with clear names.
+- Consistent style: stable formatting, naming conventions, and file structure; follow project style guides/linters.
+- Intent made explicit: meaningful names; brief comments only where intent isn’t obvious; docstrings for public APIs.
+- Single responsibility: each module/class/function does one thing; separate concerns; minimize side effects.
+- Predictable control flow: limited branching depth; early returns for guard clauses; avoid deeply nested code.
+- Good boundaries: clear interfaces; avoid leaking implementation details; use types or assertions to define expectations.
+- DRY but pragmatic: share common logic without over-abstracting; duplicate only when it improves clarity.
+- Small surfaces: limit global state; keep public APIs minimal; prefer immutability where practical.
+- Testability: code structured so it’s easy to unit/integration test; deterministic behavior; clear seams for injecting dependencies.
+- Error handling: explicit failure paths; helpful messages; avoid silent catches; clean resource management.
+- Observability: surface guarded fallbacks/edge conditions with trace/log hooks so silent behavior changes don’t hide regressions.
+- Documentation: concise README/usage notes; explain non-obvious decisions; update docs alongside code.
+- Tooling: automated formatting/linting/tests in CI; commit hooks for quick checks; steady dependency management.
+- Performance awareness: efficient enough without premature micro-optimizations; measure before tuning.
+
+## Execution Rules
+- Before planning/implementation, set up your environment using `.venv/bin/python tests/configure_pytest_environment.py` (create `.venv` if needed).
+- For each phase/stage, create and document a concrete plan before making code changes.
+- Identify risks inherent in the plan (behavioral regressions, installer failures, CI flakiness, dependency drift, user upgrade prompts) and list the mitigations/tests you will run to address those risks.
+- Track the plan and risk mitigations alongside the phase notes so they are visible during execution and review.
+- After implementing each phase/stage, document the results and outcomes for that stage (tests run, issues found, follow-ups).
+- After implementation, mark the stage as completed in the tracking tables.
+- Do not continue if you have open questions, need clarification, or prior stages are not completed; pause and document why you stopped so the next step is unblocked quickly.
+
+## Phase Overview
+
+| Phase | Description | Status |
+| --- | --- | --- |
+| 1 | Add per-group controller box mode (`last` vs `max`) with persistent cache, plus user-visible cache reset. | Completed |
+| 2 | Switch last/max tracking to use base bounds (not transformed). | Completed |
+
+## Phase Details
+
+### Phase 1: Controller Target Box Persistence
+- Goal: expose a per-group `controllerPreviewBoxMode` with `last` (default) and `max` options, and persist both across restarts.
+- `max` uses the maximum base bounds ever recorded for the group.
+- `last` uses the most recent base bounds for a visible payload group.
+- Both `last` and `max` persist in `overlay_group_cache.json`.
+- Provide a "Reset cached values" button in preferences (no debug/dev gating) to clear `overlay_group_cache.json`.
+
+Definition: "Last Visible"
+- "Last visible" means the most recent base bounds for a group where the payload is considered visible.
+- Visibility rules:
+  - Bounds width and height are strictly > 0.
+  - Messages with `ttl=0` and empty `text` are not visible.
+  - Zero-size rects are not visible.
+  - Vector payloads must have at least one point.
+
+Propagation Path (Config -> Runtime)
+1) Plugin API entry point
+   - `overlay_plugin/overlay_api.py:define_plugin_group` accepts `controller_preview_box_mode`.
+   - Store as `controllerPreviewBoxMode` under the idPrefix group in `overlay_groupings.json`.
+
+2) Overrides parsing
+   - `overlay_client/plugin_overrides.py` parses the new field from group entries.
+   - Normalize to `last` or `max`, default `last`.
+
+3) Runtime access
+   - Either:
+     - Add a new property to `GroupTransform` (e.g., `controller_preview_box_mode`),
+       and set it in `overlay_client/grouping_helper.py`, or
+     - Expose a direct lookup on the override manager (e.g.,
+       `group_controller_box_mode(plugin, suffix)`) and use it from
+       `render_surface.py`.
+   - Render path needs this setting at draw time.
+
+4) Render usage (in-game orange box)
+   - `overlay_client/render_surface.py:_paint_controller_target_box` uses the
+     mode to decide which bounds to display.
+   - `last` uses the persisted last-visible transformed bounds.
+   - `max` uses the persisted max transformed bounds, with fallback to last.
+
+Max/Last Tracking and Cache Persistence
+- Storage location: `overlay_group_cache.json` per group entry.
+- Add optional fields for last-visible and max base bounds (stored under the existing cache keys):
+  - `last_visible_transformed`: `{base_min_x, base_min_y, base_max_x, base_max_y, base_width, base_height}`
+  - `max_transformed`: `{base_min_x, base_min_y, base_max_x, base_max_y, base_width, base_height}`
+- Update policy:
+  - When a group is visible, update last-visible base bounds.
+  - Update max base bounds if the new visible bounds exceed previous max.
+  - Only use base bounds (no transformed bounds).
+
+Reset Cached Values
+- Add a "Reset cached values" button to the preferences pane UI.
+- Reset should delete or truncate `overlay_group_cache.json` to default state.
+- Ensure any in-memory cache mirrors the reset (force reload or clear).
+- Reset also clears any in-memory last/max maps immediately.
+
+Risks
+- Cache schema drift or stale values after mode toggles.
+- Oversized max bounds lingering after layout changes.
+
+Mitigations
+- Reset button to clear cached values.
+- Define a deterministic update policy tied to visibility and transformed bounds.
+- Add tests for cache read/write semantics and mode-specific selection.
+
+Decisions
+- Max only resets via the reset button (not on edit nonce changes).
+- Max comparison uses width and height only (no area-based metric).
+
+Implementation Plan
+- Define controller box mode in API/config: add `controller_preview_box_mode` to `define_plugin_group`, validate/normalize it, store `controllerPreviewBoxMode` in groupings, and expose it via overrides/runtime.
+- Persist last/max transformed bounds in cache: extend cache schema (`last_visible_transformed`/`max_transformed`), update render/cache write path to maintain them for visible groups, and update cache read helpers.
+- Select bounds by mode in the in-game target box: use last vs max from cache (with fallbacks) and wire mode lookup in render surface.
+- Add preferences "Reset cached values" button and wiring to clear the cache file and in-memory last/max maps immediately.
+- Tests and docs: add/adjust tests for mode parsing, cache persistence, target box selection, and reset behavior; update release notes if needed.
+
+| Stage | Description | Status |
+| --- | --- | --- |
+| 1.1 | Add new grouping field, parsing, and runtime access for `controllerPreviewBoxMode`. | Completed |
+| 1.2 | Persist last/max transformed bounds in cache; update render logic to select by mode. | Completed |
+| 1.3 | Add preferences reset button to clear cache; add tests. | Completed |
+
+#### Stage 1.1 Plan
+- Touch points: `overlay_plugin/overlay_api.py` (new argument + validation + storage),
+  `overlay_client/plugin_overrides.py` (parse + default), runtime access method
+  on the override manager.
+- Add a normalizer for `controller_preview_box_mode` (`last`/`max`) with a safe
+  default of `last`.
+- Tests: extend overlay API tests to cover validation + storage; add/adjust
+  override parsing tests to confirm the mode is read.
+- Risks: name mismatch between API arg and JSON field; mis-typed values ignored.
+- Mitigations: explicit normalization, tests for both accepted values and
+  invalid inputs.
+
+#### Stage 1.1 Results
+- Changes: added `controller_preview_box_mode` to `define_plugin_group`, stored
+  `controllerPreviewBoxMode` in groupings, parsed in overrides, and exposed via
+  override manager lookup.
+- Tests: `source .venv/bin/activate && python -m pytest tests/test_overlay_api.py overlay_client/tests/test_override_grouping.py -k controller_preview_box_mode`
+- Issues: none observed.
+- Follow-ups: none.
+
+#### Stage 1.2 Plan
+- Touch points: `group_cache.py` (persist `last_visible_transformed` +
+  `max_transformed`), `overlay_client/render_surface.py` (cache read/write
+  selection + controller target box mode), tests for cache persistence and
+  target-box selection.
+- Update cache writes to set `last_visible_transformed` whenever a visible group
+  has transformed bounds; update `max_transformed` when width/height exceed the
+  stored max.
+- Update target-box selection to resolve `controller_preview_box_mode` and pick
+  `last_visible_transformed` vs `max_transformed` (with `max` falling back to
+  `last`), then fall back to base cache behavior when needed.
+- Tests: add cache update coverage for `last_visible_transformed`/`max_transformed`,
+  and target-box selection coverage for `last` vs `max` modes.
+- Risks: stale cache data after override edits or offset changes; mitigate by
+  reusing existing offset/nonce gating and falling back to base cache logic,
+  plus targeted tests for the new selection path.
+
+#### Stage 1.2 Results
+- Changes: cached `last_visible_transformed` and `max_transformed` in
+  `overlay_group_cache.json`, and updated controller target box rendering to
+  choose bounds by `controller_preview_box_mode` with max->last fallback.
+- Tests: `source .venv/bin/activate && python -m pytest tests/test_group_cache_debounce.py overlay_client/tests/test_controller_target_box.py`
+- Issues: none observed.
+- Follow-ups: none.
+
+#### Stage 1.3 Plan
+- Touch points: `group_cache.py` (add cache reset helper), `overlay_client`
+  (handle reset event + clear in-memory maps), `overlay_plugin/preferences.py`
+  (preferences button + callback), `load.py` (wire callback + publish reset
+  event), and `overlay_client/launcher.py` (new event handling).
+- Implement a `GroupPlacementCache.reset()` that clears state and writes an
+  empty cache file, then add a `reset_group_cache` handler on the overlay client
+  to clear in-memory maps and force a repaint.
+- Add a "Reset cached values" button in the preferences panel that clears the
+  cache file and notifies the overlay client via a new
+  `OverlayGroupCacheReset` event.
+- Tests: add unit coverage for the cache reset path and in-memory map clearing.
+- Risks: reset button may leave overlay client maps stale if event delivery
+  fails; mitigate by clearing the file first and ensuring the event handler
+  clears in-memory state with a repaint.
+
+#### Stage 1.3 Results
+- Changes: added a preferences button to reset the group cache, wired through
+  plugin runtime to emit an `OverlayGroupCacheReset` event, and added client-side
+  cache reset handling that clears in-memory maps immediately.
+- Tests: `source .venv/bin/activate && python -m pytest tests/test_group_cache_debounce.py overlay_client/tests/test_render_surface_mixin.py`
+- Issues: none observed.
+- Follow-ups: none.
+
+### Phase 2: Base Bounds Tracking for Last/Max
+- Goal: ensure last/max cache entries are derived from base bounds so groups without transforms (e.g., default anchors/justification) still persist usable target boxes.
+- Backward compatibility: tolerate existing `last_visible_transformed`/`max_transformed` entries that still use transformed keys, but prefer base-keyed entries going forward.
+
+| Stage | Description | Status |
+| --- | --- | --- |
+| 2.1 | Update cache writes/reads to use base bounds for last/max; refresh tests/docs. | Completed |
+
+#### Stage 2.1 Plan
+- Touch points: `group_cache.py` (last/max updates from base bounds),
+  `overlay_client/render_surface.py` (cache fallback parsing for last/max),
+  `tests/test_group_cache_debounce.py`, `overlay_client/tests/test_controller_target_box.py`,
+  and this refactoring doc.
+- Update cache writes to persist base-keyed bounds in `last_visible_transformed` and `max_transformed`.
+- Update cache read helpers to treat last/max payloads as base bounds (apply offsets/anchors at draw time).
+- Tests: update cache persistence/selection tests; run targeted pytest for cache + controller target box behavior.
+- Risks: target box shifts for anchored/justified groups; mitigate by retaining transformed fallbacks and testing representative cases.
+
+#### Stage 2.1 Results
+- Changes: last/max cache entries now persist base bounds from group snapshots, and cache fallback treats last/max payloads as base bounds (with transformed fallbacks); controller target box no longer requires transformed payloads for last/max.
+- Tests: `source .venv/bin/activate && python -m pytest tests/test_group_cache_debounce.py overlay_client/tests/test_controller_target_box.py`
+- Issues: none observed.
+- Follow-ups: none.

--- a/overlay_client/launcher.py
+++ b/overlay_client/launcher.py
@@ -120,6 +120,9 @@ def _build_payload_handler(helper: DeveloperHelperController, window: OverlayWin
         if event == "OverlayOverridesPayload":
             window.apply_override_payload(payload)
             return
+        if event == "OverlayGroupCacheReset":
+            window.reset_group_cache()
+            return
         if event == "LegacyOverlay":
             payload_id = str(payload.get("id") or "").strip().lower()
             if payload_id == "overlay-controller-status":

--- a/overlay_client/legacy_processor.py
+++ b/overlay_client/legacy_processor.py
@@ -186,6 +186,7 @@ def process_legacy_payload(
             "y": int(payload.get("y", 0)),
             "size": payload.get("size", "normal"),
         }
+        data["__mo_ttl__"] = ttl
         transform_meta = payload.get("__mo_transform__")
         if isinstance(transform_meta, Mapping):
             try:
@@ -215,6 +216,7 @@ def process_legacy_payload(
                 "w": int(message.get("w", 0)),
                 "h": int(message.get("h", 0)),
             }
+            data["__mo_ttl__"] = ttl
             if trace_fn:
                 snapshot = _hashable_payload_snapshot("shape", payload)
                 trace_fn(
@@ -301,6 +303,7 @@ def process_legacy_payload(
                 "base_color": message.get("color", "white"),
                 "points": points,
             }
+            data["__mo_ttl__"] = ttl
             if trace_fn:
                 snapshot = _hashable_payload_snapshot("shape", payload)
                 trace_fn(
@@ -342,6 +345,7 @@ def process_legacy_payload(
 
         # For other shapes we keep the payload for future support/logging
         enriched = dict(message)
+        enriched["__mo_ttl__"] = ttl
         enriched.setdefault("timestamp", datetime.now(UTC).isoformat())
         store.set(
             item_id,

--- a/overlay_client/tests/test_override_grouping.py
+++ b/overlay_client/tests/test_override_grouping.py
@@ -308,6 +308,43 @@ def test_group_offsets(override_file: Path) -> None:
     assert manager.group_offsets("Example", "missing") == (0.0, 0.0)
 
 
+def test_group_controller_preview_box_mode(override_file: Path) -> None:
+    override_file.write_text(
+        json.dumps(
+            {
+                "Example": {
+                    "idPrefixGroups": {
+                        "alerts": {
+                            "idPrefixes": ["example.alert."],
+                            "controllerPreviewBoxMode": "max",
+                        },
+                        "metrics": {
+                            "idPrefixes": ["example.metric."],
+                            "controllerPreviewBoxMode": "LAST",
+                        },
+                        "default": {
+                            "idPrefixes": ["example.default."],
+                            "controllerPreviewBoxMode": "invalid",
+                        },
+                        "snake": {
+                            "idPrefixes": ["example.snake."],
+                            "controller_preview_box_mode": "max",
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    manager = _make_manager(override_file)
+    assert manager.group_controller_preview_box_mode("Example", "alerts") == "max"
+    assert manager.group_controller_preview_box_mode("Example", "metrics") == "last"
+    assert manager.group_controller_preview_box_mode("Example", "default") == "last"
+    assert manager.group_controller_preview_box_mode("Example", "snake") == "max"
+    assert manager.group_controller_preview_box_mode("Example", "missing") == "last"
+    assert manager.group_controller_preview_box_mode("Other", "alerts") == "last"
+
+
 def test_legacy_preserve_anchor_mapping(override_file: Path) -> None:
     override_file.write_text(
         json.dumps(

--- a/overlay_groupings.json
+++ b/overlay_groupings.json
@@ -135,7 +135,10 @@
           "edr-bounty"
         ],
         "idPrefixGroupAnchor": "nw",
-        "payloadJustification": "left"
+        "payloadJustification": "left",
+        "markerLabelPosition": "below",
+        "controllerPreviewBoxMode": "max",
+        "backgroundColor": null
       },
       "EDR Docking": {
         "idPrefixes": [
@@ -143,37 +146,62 @@
           "edr-docking-station-"
         ],
         "idPrefixGroupAnchor": "nw",
-        "payloadJustification": "left"
+        "payloadJustification": "left",
+        "markerLabelPosition": "below",
+        "controllerPreviewBoxMode": "max",
+        "backgroundColor": null
       },
       "EDR Intel": {
         "idPrefixes": [
           "edr-intel"
         ],
         "idPrefixGroupAnchor": "nw",
-        "payloadJustification": "left"
+        "payloadJustification": "left",
+        "markerLabelPosition": "below",
+        "controllerPreviewBoxMode": "max",
+        "backgroundColor": null
       },
       "EDR Notice": {
         "idPrefixes": [
           "edr-notice-"
         ],
         "idPrefixGroupAnchor": "nw",
-        "payloadJustification": "left"
+        "payloadJustification": "left",
+        "markerLabelPosition": "below",
+        "controllerPreviewBoxMode": "max",
+        "backgroundColor": null
       },
       "EDR Target": {
         "idPrefixes": [
           "edr-target"
         ],
         "idPrefixGroupAnchor": "nw",
-        "payloadJustification": "left"
+        "payloadJustification": "left",
+        "markerLabelPosition": "below",
+        "controllerPreviewBoxMode": "max",
+        "backgroundColor": null
       },
-      "Edr Navigation": {
+      "EDR Sitrep": {
+        "idPrefixes": [
+          "edr-sitrep-"
+        ],
+        "idPrefixGroupAnchor": "nw",
+        "payloadJustification": "left",
+        "markerLabelPosition": "below",
+        "controllerPreviewBoxMode": "max",
+        "backgroundColor": null
+      },
+      "EDR Navigation": {
         "idPrefixes": [
           "edr-navigation-"
         ],
         "idPrefixGroupAnchor": "nw",
-        "payloadJustification": "left"
+        "payloadJustification": "left",
+        "markerLabelPosition": "below",
+        "controllerPreviewBoxMode": "max",
+        "backgroundColor": null
       },
-      "Edr Navroute": {
+      "EDR Navroute": {
         "idPrefixes": [
           "edr-navroute-"
         ],
@@ -181,14 +209,9 @@
         "offsetX": 640,
         "offsetY": 5,
         "payloadJustification": "left",
-        "markerLabelPosition": "below"
-      },
-      "Edr Sitrep": {
-        "idPrefixes": [
-          "edr-sitrep-"
-        ],
-        "idPrefixGroupAnchor": "nw",
-        "payloadJustification": "left"
+        "markerLabelPosition": "below",
+        "controllerPreviewBoxMode": "last",
+        "backgroundColor": null
       }
     }
   },

--- a/overlay_settings.json
+++ b/overlay_settings.json
@@ -6,8 +6,8 @@
   "client_log_retention": 5,
   "gridlines_enabled": false,
   "gridline_spacing": 120,
-  "force_render": true,
-  "allow_force_render_release": true,
+  "force_render": false,
+  "allow_force_render_release": false,
   "force_xwayland": true,
   "physical_clamp_enabled": false,
   "physical_clamp_overrides": {},
@@ -24,7 +24,7 @@
   "nudge_overflow_payloads": false,
   "payload_nudge_gutter": 20,
   "status_message_gutter": 20,
-  "log_payloads": false,
+  "log_payloads": true,
   "payload_log_delay_seconds": 0.5,
   "controller_launch_command": "!ovr"
 }

--- a/schemas/overlay_groupings.schema.json
+++ b/schemas/overlay_groupings.schema.json
@@ -53,6 +53,12 @@
           "default": "below",
           "description": "Marker label placement relative to the marker."
         },
+        "controllerPreviewBoxMode": {
+          "type": "string",
+          "enum": ["last", "max"],
+          "default": "last",
+          "description": "Controls controller target box selection: last visible or max transformed bounds."
+        },
         "backgroundColor": {
           "oneOf": [
             {

--- a/tests/test_group_cache_debounce.py
+++ b/tests/test_group_cache_debounce.py
@@ -91,3 +91,119 @@ def test_group_cache_flush_pending_writes(tmp_path):
     meta = cache.last_write_metadata("Plugin", "G1")
     assert meta is not None
     assert meta["edit_nonce"] == "flush"
+
+
+def test_group_cache_updates_last_visible_and_max_transformed(tmp_path):
+    cache_path = tmp_path / "overlay_group_cache.json"
+    cache = group_cache.GroupPlacementCache(cache_path, debounce_seconds=0.1, logger=None)
+    normalized = {
+        "base_min_x": 0.0,
+        "base_min_y": 0.0,
+        "base_max_x": 90.0,
+        "base_max_y": 45.0,
+        "base_width": 90.0,
+        "base_height": 45.0,
+        "has_transformed": True,
+        "offset_x": 0.0,
+        "offset_y": 0.0,
+        "edit_nonce": "cache",
+        "controller_ts": 0.0,
+    }
+    first = {
+        "trans_min_x": 10.0,
+        "trans_min_y": 5.0,
+        "trans_max_x": 110.0,
+        "trans_max_y": 55.0,
+        "trans_width": 100.0,
+        "trans_height": 50.0,
+        "anchor": "nw",
+        "offset_dx": 0.0,
+        "offset_dy": 0.0,
+    }
+    cache.update_group("Plugin", "G1", normalized, first)
+    entry = cache._state["groups"]["Plugin"]["G1"]
+    assert entry["last_visible_transformed"]["base_width"] == 90.0
+    assert entry["max_transformed"]["base_width"] == 90.0
+
+    normalized_small = {
+        **normalized,
+        "base_max_x": 80.0,
+        "base_max_y": 40.0,
+        "base_width": 80.0,
+        "base_height": 40.0,
+    }
+    smaller = {
+        "trans_min_x": 10.0,
+        "trans_min_y": 5.0,
+        "trans_max_x": 90.0,
+        "trans_max_y": 45.0,
+        "trans_width": 80.0,
+        "trans_height": 40.0,
+        "anchor": "nw",
+        "offset_dx": 0.0,
+        "offset_dy": 0.0,
+    }
+    cache.update_group("Plugin", "G1", normalized_small, smaller)
+    entry = cache._state["groups"]["Plugin"]["G1"]
+    assert entry["last_visible_transformed"]["base_width"] == 80.0
+    assert entry["max_transformed"]["base_width"] == 90.0
+
+    normalized_large = {
+        **normalized,
+        "base_max_x": 120.0,
+        "base_max_y": 60.0,
+        "base_width": 120.0,
+        "base_height": 60.0,
+    }
+    larger = {
+        "trans_min_x": 10.0,
+        "trans_min_y": 5.0,
+        "trans_max_x": 130.0,
+        "trans_max_y": 65.0,
+        "trans_width": 120.0,
+        "trans_height": 60.0,
+        "anchor": "nw",
+        "offset_dx": 0.0,
+        "offset_dy": 0.0,
+    }
+    cache.update_group("Plugin", "G1", normalized_large, larger)
+    entry = cache._state["groups"]["Plugin"]["G1"]
+    assert entry["last_visible_transformed"]["base_width"] == 120.0
+    assert entry["max_transformed"]["base_width"] == 120.0
+
+
+def test_group_cache_reset_clears_state(tmp_path):
+    cache_path = tmp_path / "overlay_group_cache.json"
+    cache = group_cache.GroupPlacementCache(cache_path, debounce_seconds=0.1, logger=None)
+    normalized = {
+        "base_min_x": 0.0,
+        "base_min_y": 0.0,
+        "base_max_x": 10.0,
+        "base_max_y": 10.0,
+        "base_width": 10.0,
+        "base_height": 10.0,
+        "has_transformed": True,
+        "offset_x": 0.0,
+        "offset_y": 0.0,
+        "edit_nonce": "reset",
+        "controller_ts": 0.0,
+    }
+    transformed = {
+        "trans_min_x": 1.0,
+        "trans_min_y": 2.0,
+        "trans_max_x": 11.0,
+        "trans_max_y": 12.0,
+        "trans_width": 10.0,
+        "trans_height": 10.0,
+        "anchor": "nw",
+        "offset_dx": 0.0,
+        "offset_dy": 0.0,
+    }
+    cache.update_group("Plugin", "G1", normalized, transformed)
+    cache.flush_pending()
+    assert cache._state["groups"]["Plugin"]["G1"]["base"]["base_min_x"] == 0.0
+
+    cache.reset()
+    assert cache._state["groups"] == {}
+    raw = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert raw["groups"] == {}

--- a/tests/test_overlay_api.py
+++ b/tests/test_overlay_api.py
@@ -239,6 +239,37 @@ def test_define_plugin_group_updates_marker_label_position(grouping_store):
     payload = _load(grouping_store)
     assert payload["Example"]["idPrefixGroups"]["alerts"]["markerLabelPosition"] == "centered"
 
+def test_define_plugin_group_sets_controller_preview_box_mode(grouping_store):
+    overlay_api.define_plugin_group(
+        plugin_group="Example",
+        id_prefix_group="alerts",
+        id_prefixes=["example-alert-"],
+        controller_preview_box_mode="max",
+    )
+
+    payload = _load(grouping_store)
+    group = payload["Example"]["idPrefixGroups"]["alerts"]
+    assert group["controllerPreviewBoxMode"] == "max"
+
+
+def test_define_plugin_group_updates_controller_preview_box_mode(grouping_store):
+    overlay_api.define_plugin_group(
+        plugin_group="Example",
+        id_prefix_group="alerts",
+        id_prefixes=["example-alert-"],
+        controller_preview_box_mode="last",
+    )
+
+    updated = overlay_api.define_plugin_group(
+        plugin_group="Example",
+        id_prefix_group="alerts",
+        controller_preview_box_mode="max",
+    )
+    assert updated is True
+
+    payload = _load(grouping_store)
+    assert payload["Example"]["idPrefixGroups"]["alerts"]["controllerPreviewBoxMode"] == "max"
+
 
 def test_define_plugin_group_requires_id_group_for_payload_justification(grouping_store):
     with pytest.raises(PluginGroupingError):
@@ -265,6 +296,13 @@ def test_define_plugin_group_requires_id_group_for_marker_label_position(groupin
             marker_label_position="below",
         )
 
+def test_define_plugin_group_requires_id_group_for_controller_preview_box_mode(grouping_store):
+    with pytest.raises(PluginGroupingError):
+        overlay_api.define_plugin_group(
+            plugin_group="Example",
+            controller_preview_box_mode="max",
+        )
+
 
 def test_define_plugin_group_validates_marker_label_position_token(grouping_store):
     with pytest.raises(PluginGroupingError):
@@ -273,6 +311,15 @@ def test_define_plugin_group_validates_marker_label_position_token(grouping_stor
             id_prefix_group="alerts",
             id_prefixes=["example-"],
             marker_label_position="low",
+        )
+
+def test_define_plugin_group_validates_controller_preview_box_mode_token(grouping_store):
+    with pytest.raises(PluginGroupingError):
+        overlay_api.define_plugin_group(
+            plugin_group="Example",
+            id_prefix_group="alerts",
+            id_prefixes=["example-"],
+            controller_preview_box_mode="largest",
         )
 
 

--- a/utils/plugin_group_manager.py
+++ b/utils/plugin_group_manager.py
@@ -60,6 +60,8 @@ PAYLOAD_JUSTIFICATION_CHOICES = ("left", "center", "right")
 DEFAULT_PAYLOAD_JUSTIFICATION = "left"
 MARKER_LABEL_POSITION_CHOICES = ("below", "above", "centered")
 DEFAULT_MARKER_LABEL_POSITION = "below"
+CONTROLLER_PREVIEW_BOX_MODE_CHOICES = ("last", "max")
+DEFAULT_CONTROLLER_PREVIEW_BOX_MODE = "last"
 GENERIC_PAYLOAD_TOKENS = {"vect", "shape", "text"}
 GROUP_SELECTOR_STYLE = "ModernOverlayGroupSelect.TCombobox"
 LEFT_COLUMN_WIDTH = 180
@@ -719,6 +721,17 @@ class GroupConfigStore:
         return None
 
     @staticmethod
+    def _normalise_controller_preview_box_mode(value: Any) -> Optional[str]:
+        if not isinstance(value, str):
+            return None
+        token = value.strip().lower()
+        if not token:
+            return None
+        if token in CONTROLLER_PREVIEW_BOX_MODE_CHOICES:
+            return token
+        return None
+
+    @staticmethod
     def _clean_offset_value(value: Any) -> Optional[float]:
         numeric: Optional[float]
         if isinstance(value, (int, float)):
@@ -780,6 +793,11 @@ class GroupConfigStore:
         )
         if marker_label_position:
             cleaned["markerLabelPosition"] = marker_label_position
+        controller_preview_box_mode = self._normalise_controller_preview_box_mode(
+            spec.get("controllerPreviewBoxMode") or spec.get("controller_preview_box_mode")
+        )
+        if controller_preview_box_mode:
+            cleaned["controllerPreviewBoxMode"] = controller_preview_box_mode
         if "backgroundColor" in spec or "background_color" in spec:
             raw_color = spec.get("backgroundColor") or spec.get("background_color")
             if raw_color is None:
@@ -864,6 +882,13 @@ class GroupConfigStore:
                             marker_label_position = DEFAULT_MARKER_LABEL_POSITION
                         if marker_label_position not in MARKER_LABEL_POSITION_CHOICES:
                             marker_label_position = DEFAULT_MARKER_LABEL_POSITION
+                        raw_preview_mode = spec.get("controllerPreviewBoxMode")
+                        if isinstance(raw_preview_mode, str) and raw_preview_mode.strip():
+                            controller_preview_box_mode = raw_preview_mode.strip().lower()
+                        else:
+                            controller_preview_box_mode = DEFAULT_CONTROLLER_PREVIEW_BOX_MODE
+                        if controller_preview_box_mode not in CONTROLLER_PREVIEW_BOX_MODE_CHOICES:
+                            controller_preview_box_mode = DEFAULT_CONTROLLER_PREVIEW_BOX_MODE
                         view_entries.append(
                             {
                                 "label": label,
@@ -874,6 +899,7 @@ class GroupConfigStore:
                                 "offsetY": spec.get("offsetY"),
                                 "payloadJustification": justification,
                                 "markerLabelPosition": marker_label_position,
+                                "controllerPreviewBoxMode": controller_preview_box_mode,
                                 "backgroundColor": spec.get("backgroundColor"),
                                 "backgroundBorderWidth": spec.get("backgroundBorderWidth"),
                                 "notes": notes,
@@ -995,6 +1021,7 @@ class GroupConfigStore:
         offset_y: Optional[object] = None,
         payload_justification: Optional[str] = None,
         marker_label_position: Optional[str] = None,
+        controller_preview_box_mode: Optional[str] = None,
         background_color: Optional[str] = None,
         background_border_width: Optional[object] = None,
     ) -> None:
@@ -1017,6 +1044,13 @@ class GroupConfigStore:
         )
         if not marker_label_position_token:
             marker_label_position_token = DEFAULT_MARKER_LABEL_POSITION
+        controller_preview_box_mode_token = (
+            self._normalise_controller_preview_box_mode(controller_preview_box_mode)
+            if controller_preview_box_mode is not None
+            else None
+        )
+        if not controller_preview_box_mode_token:
+            controller_preview_box_mode_token = DEFAULT_CONTROLLER_PREVIEW_BOX_MODE
         try:
             normalized_color = _normalise_background_color(background_color) if background_color is not None else None
         except PluginGroupingError as exc:
@@ -1051,6 +1085,7 @@ class GroupConfigStore:
                 spec_payload["offsetY"] = offset_y_value
             spec_payload["payloadJustification"] = justification_token
             spec_payload["markerLabelPosition"] = marker_label_position_token
+            spec_payload["controllerPreviewBoxMode"] = controller_preview_box_mode_token
             if background_color is not None:
                 spec_payload["backgroundColor"] = normalized_color
             if background_border_width is not None:
@@ -1073,6 +1108,7 @@ class GroupConfigStore:
         offset_y: Optional[object] = None,
         payload_justification: Optional[object] = None,
         marker_label_position: Optional[object] = None,
+        controller_preview_box_mode: Optional[object] = None,
         background_color: object = _MISSING,
         background_border_width: object = _MISSING,
     ) -> None:
@@ -1132,6 +1168,12 @@ class GroupConfigStore:
                     target_spec["markerLabelPosition"] = marker_label_position_token
                 else:
                     target_spec.pop("markerLabelPosition", None)
+            if controller_preview_box_mode is not None:
+                preview_mode_token = self._normalise_controller_preview_box_mode(controller_preview_box_mode)
+                if preview_mode_token:
+                    target_spec["controllerPreviewBoxMode"] = preview_mode_token
+                else:
+                    target_spec.pop("controllerPreviewBoxMode", None)
             if background_color is not _MISSING:
                 if background_color is None or background_color == "":
                     target_spec["backgroundColor"] = None
@@ -1346,29 +1388,45 @@ class NewGroupingDialog(simpledialog.Dialog):
             state="readonly",
         ).grid(row=5, column=1, sticky="w")
 
-        ttk.Label(master, text="Offset X (px)").grid(row=6, column=0, sticky="w")
+        ttk.Label(master, text="Controller preview box").grid(row=6, column=0, sticky="w")
+        suggestion_preview = str(
+            self._suggestion.get("controllerPreviewBoxMode")
+            or self._suggestion.get("controller_preview_box_mode")
+            or DEFAULT_CONTROLLER_PREVIEW_BOX_MODE
+        ).strip().lower()
+        if suggestion_preview not in CONTROLLER_PREVIEW_BOX_MODE_CHOICES:
+            suggestion_preview = DEFAULT_CONTROLLER_PREVIEW_BOX_MODE
+        self.controller_preview_box_mode_var = tk.StringVar(value=suggestion_preview)
+        ttk.Combobox(
+            master,
+            values=CONTROLLER_PREVIEW_BOX_MODE_CHOICES,
+            textvariable=self.controller_preview_box_mode_var,
+            state="readonly",
+        ).grid(row=6, column=1, sticky="w")
+
+        ttk.Label(master, text="Offset X (px)").grid(row=7, column=0, sticky="w")
         self.offset_x_var = tk.StringVar(value=self._format_initial_offset(self._suggestion.get("offsetX")))
-        ttk.Entry(master, textvariable=self.offset_x_var, width=40).grid(row=6, column=1, sticky="ew")
+        ttk.Entry(master, textvariable=self.offset_x_var, width=40).grid(row=7, column=1, sticky="ew")
 
-        ttk.Label(master, text="Offset Y (px)").grid(row=7, column=0, sticky="w")
+        ttk.Label(master, text="Offset Y (px)").grid(row=8, column=0, sticky="w")
         self.offset_y_var = tk.StringVar(value=self._format_initial_offset(self._suggestion.get("offsetY")))
-        ttk.Entry(master, textvariable=self.offset_y_var, width=40).grid(row=7, column=1, sticky="ew")
+        ttk.Entry(master, textvariable=self.offset_y_var, width=40).grid(row=8, column=1, sticky="ew")
 
-        ttk.Label(master, text="Background color (#RRGGBB[AA])").grid(row=8, column=0, sticky="w")
+        ttk.Label(master, text="Background color (#RRGGBB[AA])").grid(row=9, column=0, sticky="w")
         self.background_color_var = tk.StringVar(value=str(self._suggestion.get("backgroundColor") or ""))
-        ttk.Entry(master, textvariable=self.background_color_var, width=40).grid(row=8, column=1, sticky="ew")
+        ttk.Entry(master, textvariable=self.background_color_var, width=40).grid(row=9, column=1, sticky="ew")
 
-        ttk.Label(master, text="Background border (0–10 px)").grid(row=9, column=0, sticky="w")
+        ttk.Label(master, text="Background border (0–10 px)").grid(row=10, column=0, sticky="w")
         self.background_border_var = tk.StringVar(
             value=str(self._suggestion.get("backgroundBorderWidth", ""))
         )
         ttk.Spinbox(master, from_=0, to=10, textvariable=self.background_border_var, width=6).grid(
-            row=9, column=1, sticky="w"
+            row=10, column=1, sticky="w"
         )
 
-        ttk.Label(master, text="Notes").grid(row=10, column=0, sticky="w")
+        ttk.Label(master, text="Notes").grid(row=11, column=0, sticky="w")
         self.notes_var = tk.StringVar(value=str(self._suggestion.get("notes") or ""))
-        ttk.Entry(master, textvariable=self.notes_var, width=40).grid(row=10, column=1, sticky="ew")
+        ttk.Entry(master, textvariable=self.notes_var, width=40).grid(row=11, column=1, sticky="ew")
         return master
 
     def validate(self) -> bool:  # type: ignore[override]
@@ -1412,6 +1470,7 @@ class NewGroupingDialog(simpledialog.Dialog):
             "anchor": self.anchor_var.get().strip(),
             "payload_justification": self.justification_var.get().strip(),
             "marker_label_position": self.marker_label_position_var.get().strip(),
+            "controller_preview_box_mode": self.controller_preview_box_mode_var.get().strip(),
             "offset_x": self.offset_x_var.get().strip(),
             "offset_y": self.offset_y_var.get().strip(),
             "background_color": getattr(self, "_validated_background_color", None),
@@ -1557,27 +1616,41 @@ class EditGroupingDialog(simpledialog.Dialog):
             state="readonly",
         ).grid(row=6, column=1, sticky="w")
 
-        ttk.Label(master, text="Offset X (px)").grid(row=7, column=0, sticky="w")
+        ttk.Label(master, text="Controller preview box").grid(row=7, column=0, sticky="w")
+        preview_box_mode = str(
+            self._entry.get("controllerPreviewBoxMode") or DEFAULT_CONTROLLER_PREVIEW_BOX_MODE
+        ).strip().lower()
+        if preview_box_mode not in CONTROLLER_PREVIEW_BOX_MODE_CHOICES:
+            preview_box_mode = DEFAULT_CONTROLLER_PREVIEW_BOX_MODE
+        self.controller_preview_box_mode_var = tk.StringVar(value=preview_box_mode)
+        ttk.Combobox(
+            master,
+            values=CONTROLLER_PREVIEW_BOX_MODE_CHOICES,
+            textvariable=self.controller_preview_box_mode_var,
+            state="readonly",
+        ).grid(row=7, column=1, sticky="w")
+
+        ttk.Label(master, text="Offset X (px)").grid(row=8, column=0, sticky="w")
         self.offset_x_var = tk.StringVar(value=self._format_initial_offset(self._entry.get("offsetX")))
-        ttk.Entry(master, textvariable=self.offset_x_var, width=40).grid(row=7, column=1, sticky="ew")
+        ttk.Entry(master, textvariable=self.offset_x_var, width=40).grid(row=8, column=1, sticky="ew")
 
-        ttk.Label(master, text="Offset Y (px)").grid(row=8, column=0, sticky="w")
+        ttk.Label(master, text="Offset Y (px)").grid(row=9, column=0, sticky="w")
         self.offset_y_var = tk.StringVar(value=self._format_initial_offset(self._entry.get("offsetY")))
-        ttk.Entry(master, textvariable=self.offset_y_var, width=40).grid(row=8, column=1, sticky="ew")
+        ttk.Entry(master, textvariable=self.offset_y_var, width=40).grid(row=9, column=1, sticky="ew")
 
-        ttk.Label(master, text="Background color (#RRGGBB[AA])").grid(row=9, column=0, sticky="w")
+        ttk.Label(master, text="Background color (#RRGGBB[AA])").grid(row=10, column=0, sticky="w")
         self.background_color_var = tk.StringVar(value=str(self._entry.get("backgroundColor") or ""))
-        ttk.Entry(master, textvariable=self.background_color_var, width=40).grid(row=9, column=1, sticky="ew")
+        ttk.Entry(master, textvariable=self.background_color_var, width=40).grid(row=10, column=1, sticky="ew")
 
-        ttk.Label(master, text="Background border (0–10 px)").grid(row=10, column=0, sticky="w")
+        ttk.Label(master, text="Background border (0–10 px)").grid(row=11, column=0, sticky="w")
         self.background_border_var = tk.StringVar(value=str(self._entry.get("backgroundBorderWidth") or ""))
         ttk.Spinbox(master, from_=0, to=10, textvariable=self.background_border_var, width=6).grid(
-            row=10, column=1, sticky="w"
+            row=11, column=1, sticky="w"
         )
 
-        ttk.Label(master, text="Notes").grid(row=11, column=0, sticky="w")
+        ttk.Label(master, text="Notes").grid(row=12, column=0, sticky="w")
         self.notes_var = tk.StringVar(value=str(self._entry.get("notes") or ""))
-        ttk.Entry(master, textvariable=self.notes_var, width=40).grid(row=11, column=1, sticky="ew")
+        ttk.Entry(master, textvariable=self.notes_var, width=40).grid(row=12, column=1, sticky="ew")
         return master
 
     def validate(self) -> bool:  # type: ignore[override]
@@ -1603,6 +1676,7 @@ class EditGroupingDialog(simpledialog.Dialog):
             "anchor": self.anchor_var.get().strip(),
             "payload_justification": self.justification_var.get().strip(),
             "marker_label_position": self.marker_label_position_var.get().strip(),
+            "controller_preview_box_mode": self.controller_preview_box_mode_var.get().strip(),
             "offset_x": self.offset_x_var.get().strip(),
             "offset_y": self.offset_y_var.get().strip(),
             "background_color": getattr(self, "_validated_background_color", None),
@@ -2560,6 +2634,13 @@ class PluginGroupManagerApp:
                 marker_label_value = DEFAULT_MARKER_LABEL_POSITION
             if marker_label_value not in MARKER_LABEL_POSITION_CHOICES:
                 marker_label_value = DEFAULT_MARKER_LABEL_POSITION
+            preview_box_value = entry.get("controllerPreviewBoxMode") or DEFAULT_CONTROLLER_PREVIEW_BOX_MODE
+            if isinstance(preview_box_value, str):
+                preview_box_value = preview_box_value.strip().lower() or DEFAULT_CONTROLLER_PREVIEW_BOX_MODE
+            else:
+                preview_box_value = DEFAULT_CONTROLLER_PREVIEW_BOX_MODE
+            if preview_box_value not in CONTROLLER_PREVIEW_BOX_MODE_CHOICES:
+                preview_box_value = DEFAULT_CONTROLLER_PREVIEW_BOX_MODE
             notes_text = entry.get("notes") or "- none -"
             left_cell = ttk.Frame(entry_frame, width=LEFT_COLUMN_WIDTH)
             left_cell.grid(row=1, column=0, sticky="nw", pady=(2, 0))
@@ -2567,6 +2648,7 @@ class PluginGroupManagerApp:
             ttk.Label(left_cell, text=f"Anchor: {anchor_value}").pack(anchor="w")
             ttk.Label(left_cell, text=f"Justification: {justification_value}").pack(anchor="w", pady=(2, 0))
             ttk.Label(left_cell, text=f"Marker label: {marker_label_value}").pack(anchor="w", pady=(2, 0))
+            ttk.Label(left_cell, text=f"Controller preview: {preview_box_value}").pack(anchor="w", pady=(2, 0))
             offset_label = (
                 f"Offset: x={self._format_offset_value(entry.get('offsetX'))}, "
                 f"y={self._format_offset_value(entry.get('offsetY'))}"
@@ -3240,6 +3322,7 @@ class PluginGroupManagerApp:
                 offset_y=data.get("offset_y"),
                 payload_justification=data.get("payload_justification"),
                 marker_label_position=data.get("marker_label_position"),
+                controller_preview_box_mode=data.get("controller_preview_box_mode"),
                 background_color=data.get("background_color"),
                 background_border_width=data.get("background_border_width"),
             )
@@ -3274,6 +3357,7 @@ class PluginGroupManagerApp:
                 offset_y=data.get("offset_y"),
                 payload_justification=data.get("payload_justification"),
                 marker_label_position=data.get("marker_label_position"),
+                controller_preview_box_mode=data.get("controller_preview_box_mode"),
                 background_color=data.get("background_color"),
                 background_border_width=data.get("background_border_width"),
             )


### PR DESCRIPTION
Provide a new option in `define_plugin_group` called `controller_preview_box_mode` (enum: `last` (default), `max`).

This is used to determine how to size the orange border that shows up when the overlay controller is open. Some plugins send clear messages or slowly decay their on-screen HUDs so the border will shrink. By setting this property to `last`, it will use the last visible payload to determine the size of the orange border. By setting this property to `max`, it will use the largest visible payload seen to determine the size of the orange border. This now also includes a "Reset cached values" button on the pref pane to clear `overlay_group_cache.json` should it go astray.

