### PR TITLE
Fixed issue where updating README with latest VT source code report f…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,7 +20,7 @@
   - Cleaned up some inconsistencies with pref pane, internal messages being sent, and plugged `define_plugin_group` api into `utils/plugin_group_manager.py` for add/update operations.
   - Cleaned up a noisy log message (client connected)
   - Addresses [#56](https://github.com/SweetJonnySauce/EDMCModernOverlay/issues/56) by creating a vt_transparency.html asset you can download and view.
-
+  - Fixed issue where updating README with latest VT source code report failed after locking down `main` from commits.
   
 ## 0.7.5
 - Features & Improvements:


### PR DESCRIPTION
…ailed after locking down `main` from commits.


