### PR TITLE
Added module checks for pywayland and PyQt6.QtWaylandClient 

### DIFF
--- a/utils/collect_overlay_debug_linux.sh
+++ b/utils/collect_overlay_debug_linux.sh
@@ -452,7 +452,12 @@ abbrev_path() {
 
 check_python_modules() {
     print_header "Python Module Checks"
-    local modules=(pydbus)
+    echo "Note: pywayland and PyQt6.QtWaylandClient are Wayland-only helpers."
+    local modules=(
+        pydbus
+        pywayland
+        PyQt6.QtWaylandClient
+    )
     local interpreters=()
     local venv_python="${OVERLAY_CLIENT_DIR}/.venv/bin/python"
     if [[ -x "$venv_python" ]]; then


### PR DESCRIPTION
Added module checks for pywayland and PyQt6.QtWaylandClient in collect_overlay_debug_linux.sh so the diagnostics now cover the wlroots + layer‑shell paths.
