### PR TITLE
Fixes Preview box not moving with Overlay Controller when payload is not painted.

### DIFF
--- a/overlay_client/control_surface.py
+++ b/overlay_client/control_surface.py
@@ -820,6 +820,9 @@ class ControlSurfaceMixin:
                 self._payload_model,
                 _CLIENT_LOGGER.debug,
             )
+            self._last_visible_overlay_bounds_for_target = {}
+            self._last_overlay_bounds_for_target = {}
+            self._last_transform_by_group = {}
             self._mark_legacy_cache_dirty()
             self._request_repaint("override_reload", immediate=True)
             _CLIENT_LOGGER.debug("Override reload handled (nonce=%s)", nonce or "none")
@@ -845,6 +848,9 @@ class ControlSurfaceMixin:
                 mgr._controller_active_nonce = nonce_val  # type: ignore[attr-defined]
                 mgr._controller_active_nonce_ts = time.time()  # type: ignore[attr-defined]
             mgr.apply_override_payload(overrides_map, nonce_val)
+            self._last_visible_overlay_bounds_for_target = {}
+            self._last_overlay_bounds_for_target = {}
+            self._last_transform_by_group = {}
             self._mark_legacy_cache_dirty()
             self._request_repaint("override_payload", immediate=True)
             _CLIENT_LOGGER.debug("Override payload applied (nonce=%s)", nonce_val or "none")


### PR DESCRIPTION
…not painted.

Fixes #128

## EDMC compliance checks

- [ ] Python baseline matches `docs/compliance/edmc_python_version.txt` (run `python scripts/check_edmc_python.py`; set `ALLOW_EDMC_PYTHON_MISMATCH=1` only for non-release/development work)
- [ ] EDMC Releases/Discussions reviewed for plugin-impacting changes (link or note findings)
- [ ] Monitor gating intact (`monitor.game_running()`/`monitor.is_live_galaxy()` in `load.py`)
- [ ] Folder/plugin naming exception acknowledged or resolved for release (`EDMCModernOverlayDev` vs `EDMCModernOverlay`)

## Summary

- Changes:
- Testing:

