### PR TITLE
Force venv creation to make copy of host python

### DIFF
--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -2032,7 +2032,7 @@ create_venv_and_install() {
     if [[ ! -d overlay_client/.venv ]]; then
         echo "🐍 Creating Python virtual environment..."
         log_command python3 -m venv overlay_client/.venv
-        python3 -m venv overlay_client/.venv
+        python3 -m venv overlay_client/.venv --copies
     fi
 
     # shellcheck disable=SC1091


### PR DESCRIPTION
## EDMC compliance checks

- [ ] Python baseline matches `docs/compliance/edmc_python_version.txt` (run `python scripts/check_edmc_python.py`; set `ALLOW_EDMC_PYTHON_MISMATCH=1` only for non-release/development work)
- [ ] EDMC Releases/Discussions reviewed for plugin-impacting changes (link or note findings)
- [ ] Monitor gating intact (`monitor.game_running()`/`monitor.is_live_galaxy()` in `load.py`)
- [ ] Folder/plugin naming exception acknowledged or resolved for release (`EDMCModernOverlayDev` vs `EDMCModernOverlay`)

## Summary

- Changes: This change forces the virtual env creation to make a copy of the host's python instead of using symlinks.
- Testing: See below

### Issue

After running the installer on Gentoo linux the overlay does not load and I see this message in the EDMC logs:

```
Jan 24 16:01:27 foobar flatpak[28738]: 2026-01-24 22:01:27.387 UTC - WARNING - 3:140112969231296:3 <plugins>.EDMCModernOverlay.load._EDMCLogHandler.emit:341: [22:01:27] [EDMCModernOverlay] Flatpak detected but no host Python interpreter found. Ensure overlay_client/.venv exists (or set EDMC_OVERLAY_HOST_PYTHON) with the overlay dependencies.
Jan 24 16:01:27 foobar flatpak[28738]: 2026-01-24 22:01:27.387 UTC - INFO - 3:140112969231296:3 <plugins>.EDMCModernOverlay.load._EDMCLogHandler.emit:341: [22:01:27] [EDMCModernOverlay] Overlay client environment not found. Create overlay_client/.venv (or set EDMC_OVERLAY_PYTHON) and restart EDMC Modern Overlay.
Jan 24 16:01:27 foobar flatpak[28738]: 2026-01-24 22:01:27.388 UTC - ERROR - 3:140112969231296:3 <plugins>.EDMCModernOverlay.load._EDMCLogHandler.emit:341: [22:01:27] [EDMCModernOverlay] Overlay launch aborted: no overlay Python interpreter available under overlay_client/.venv or EDMC_OVERLAY_PYTHON.
```

Further investigation in the flatpak show that the installer only symlinked to the host's python interpreter, which is not available inside of the flatpak:

```
$ flatpak enter io.edcd.EDMarketConnector bash
bash-5.3$ ls -lah .var/app/io.edcd.EDMarketConnector/data/EDMarketConnector/plugins/EDMCModernOverlay/overlay_client/.venv/bin/
total 52K
drwxr-xr-x 2 david david 4.0K Jan 24 15:55 .
drwxr-xr-x 5 david david 4.0K Jan 24 15:55 ..
-rw-r--r-- 1 david david 8.9K Jan 13 22:25 Activate.ps1
-rw-r--r-- 1 david david 2.3K Jan 24 15:55 activate
-rw-r--r-- 1 david david 1007 Jan 24 15:55 activate.csh
-rw-r--r-- 1 david david 2.3K Jan 24 15:55 activate.fish
-rwxr-xr-x 1 david david  339 Jan 24 15:55 pip
-rwxr-xr-x 1 david david  339 Jan 24 15:55 pip3
-rwxr-xr-x 1 david david  339 Jan 24 15:55 pip3.13
-rwxr-xr-x 1 david david  340 Jan 24 15:55 pylupdate6
lrwxrwxrwx 1 david david    7 Jan 24 15:55 python -> python3
lrwxrwxrwx 1 david david   39 Jan 24 15:55 python3 -> /usr/lib/python-exec/python3.13/python3
lrwxrwxrwx 1 david david    7 Jan 24 15:55 python3.13 -> python3
-rwxr-xr-x 1 david david  332 Jan 24 15:55 pyuic6
bash-5.3$ ls -lah /usr/lib/python-exec
ls: cannot access '/usr/lib/python-exec': No such file or directory
```

### The Fix

This change adds the `--copies` flag to the venv creation to copy the host's python interpreter into the virtual environment instead of using symlinks. Link to the relevant documentation:
https://docs.python.org/3/library/venv.html#cmdoption-venv-copies

After this change:

```
$ flatpak enter io.edcd.EDMarketConnector bash
bash-5.3$ ls -lah .var/app/io.edcd.EDMarketConnector/data/EDMarketConnector/plugins/EDMCModernOverlay/overlay_client/.venv/bin/
total 100K
drwxr-xr-x 2 david david 4.0K Jan 24 16:16 .
drwxr-xr-x 5 david david 4.0K Jan 24 16:16 ..
-rw-r--r-- 1 david david 8.9K Jan 13 22:25 Activate.ps1
-rw-r--r-- 1 david david 2.3K Jan 24 16:16 activate
-rw-r--r-- 1 david david 1007 Jan 24 16:16 activate.csh
-rw-r--r-- 1 david david 2.3K Jan 24 16:16 activate.fish
-rwxr-xr-x 1 david david  339 Jan 24 16:16 pip
-rwxr-xr-x 1 david david  339 Jan 24 16:16 pip3
-rwxr-xr-x 1 david david  339 Jan 24 16:16 pip3.13
-rwxr-xr-x 1 david david  340 Jan 24 16:16 pylupdate6
-rwxr-xr-x 1 david david  16K Jan 24 16:16 python
-rwxr-xr-x 1 david david  16K Jan 24 16:16 python3
-rwxr-xr-x 1 david david  16K Jan 24 16:16 python3.13
-rwxr-xr-x 1 david david  332 Jan 24 16:16 pyuic6
```

And the overlay loads without issue.
