### PR TITLE
Update README with 0.7.7 Beta #1 release info

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [build-url]: https://github.com/SweetJonnySauce/EDMCModernOverlay/actions/workflows/ci.yml
 
 🔥🔥🔥0.7.6 has been released. Get it [here](https://github.com/SweetJonnySauce/EDMCModernOverlay/releases/latest)🔥🔥🔥
+
 0.7.7 Beta #1 is now available. Bugs may be present. Get it [here](https://github.com/SweetJonnySauce/EDMCModernOverlay/releases/tag/0.7.7-b1)
 
 EDMC Modern Overlay (packaged as `EDMCModernOverlay`) is a drop-in replacement for [EDMCOverlay](https://github.com/inorton/EDMCOverlay) and [edmcoverlay2](https://github.com/pan-mroku/edmcoverlay2). It is a cross-platform (Windows and Linux), two-part implementation (plugin and overlay client) for Elite Dangerous Market Connector ([EDMC](https://github.com/EDCD/EDMarketConnector)). It streams data from EDMC plugins over a lightweight TCP socket and displays a transparent, click-through PyQt6 heads-up display on the Elite Dangerous game. It runs in both fullscreen borderless and windowed mode on any display size. The [plugin releases](https://github.com/SweetJonnySauce/EDMC-ModernOverlay/releases/latest) ship with both Windows and Linux installers.


### PR DESCRIPTION
Added announcement for version 0.7.7 Beta #1 in README.

## EDMC compliance checks

- [ ] Python baseline matches `docs/compliance/edmc_python_version.txt` (run `python scripts/check_edmc_python.py`; set `ALLOW_EDMC_PYTHON_MISMATCH=1` only for non-release/development work)
- [ ] EDMC Releases/Discussions reviewed for plugin-impacting changes (link or note findings)
- [ ] Monitor gating intact (`monitor.game_running()`/`monitor.is_live_galaxy()` in `load.py`)
- [ ] Folder/plugin naming exception acknowledged or resolved for release (`EDMCModernOverlayDev` vs `EDMCModernOverlay`)

## Summary

- Changes:
- Testing:

