### PR TITLE
Update release version to 0.8.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@
 [build-badge]: https://github.com/SweetJonnySauce/EDMCModernOverlay/actions/workflows/ci.yml/badge.svg?branch=main
 [build-url]: https://github.com/SweetJonnySauce/EDMCModernOverlay/actions/workflows/ci.yml
 
-🔥🔥🔥0.7.7 has been released. Get it [here](https://github.com/SweetJonnySauce/EDMCModernOverlay/releases/latest)🔥🔥🔥
-
-❗❗❗[0.8.0 Beta](https://github.com/SweetJonnySauce/EDMCModernOverlay/releases/tag/0.8.0-beta-1) is now available for testing.❗❗❗
+🔥🔥🔥0.8.0 has been released. Get it [here](https://github.com/SweetJonnySauce/EDMCModernOverlay/releases/latest)🔥🔥🔥
 
 EDMC Modern Overlay (packaged as `EDMCModernOverlay`) replaces [EDMCOverlay](https://github.com/inorton/EDMCOverlay) and [edmcoverlay2](https://github.com/pan-mroku/edmcoverlay2). It is a cross-platform (Windows and Linux) plugin for Elite Dangerous Market Connector ([EDMC](https://github.com/EDCD/EDMarketConnector)). It streams data from other EDMC plugins to be displayed in your game window. EDMCModernOverlay supports fullscreen, borderless, and windowed mode on any display size. It also now has a standalone mode as an experimental feature in 0.7.7 for use in SteamVR. The [plugin releases](https://github.com/SweetJonnySauce/EDMC-ModernOverlay/releases/latest) include Windows (powershell and .exe) and Linux installers.
 


### PR DESCRIPTION
## EDMC compliance checks

- [ ] Python baseline matches `docs/compliance/edmc_python_version.txt` (run `python scripts/check_edmc_python.py`; set `ALLOW_EDMC_PYTHON_MISMATCH=1` only for non-release/development work)
- [ ] EDMC Releases/Discussions reviewed for plugin-impacting changes (link or note findings)
- [ ] Monitor gating intact (`monitor.game_running()`/`monitor.is_live_galaxy()` in `load.py`)
- [ ] Folder/plugin naming exception acknowledged or resolved for release (`EDMCModernOverlayDev` vs `EDMCModernOverlay`)

## Summary

- Changes:
- Testing:

