### PR TITLE
add linux subsystemm

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,6 +8,7 @@ Got an idea? Please open up a new issue for consideration/tracking.
 | --- | --- | --- |
 | Linux standalone mode | Allow the overlay to run as a standalone selectable app. Useful for selecting it in SteamVR (potentialy). | [Issue #193](https://github.com/SweetJonnySauce/EDMCModernOverlay/issues/193) |
 | Steamdeck compatibility | Updates necessary to get the overlay to display on Steamdeck | [Issue #146](https://github.com/SweetJonnySauce/EDMCModernOverlay/issues/146) |
+| Linux backend | Refactor the Linux implementation to create a capability driven subsystem | |
 | Per-ship profiles | Enable per-ship overlay configuration profiles to be created and used. | [Issue #159](https://github.com/SweetJonnySauce/EDMCModernOverlay/issues/159) |
 | Scaling controls | Enable CMDRs to grow/shrink overlays using the Overlay Controller. Scaling Controls plus some EDR config changes is expected to address the issue of EDR navroute not spanning the entire screen width on ultrawide monitors.  | [Issue #47](https://github.com/SweetJonnySauce/EDMCModernOverlay/issues/47#issuecomment-3902228152)|
 | Run Headless | Run EDMCModernOverlay without EDMC. This would allow non-EDMC apps to use EDMCModernOverlay without EDMC. In theory, nothing should be stopping other apps from using EDMCModernOverlay today (all they need to do is send a well formed message to the socket) but this feature would allow the overlay to run without EDMC | [Issue #192](https://github.com/SweetJonnySauce/EDMCModernOverlay/issues/192) |


### PR DESCRIPTION
## EDMC compliance checks

- [ ] Python baseline matches `docs/compliance/edmc_python_version.txt` (run `python scripts/check_edmc_python.py`; set `ALLOW_EDMC_PYTHON_MISMATCH=1` only for non-release/development work)
- [ ] EDMC Releases/Discussions reviewed for plugin-impacting changes (link or note findings)
- [ ] Monitor gating intact (`monitor.game_running()`/`monitor.is_live_galaxy()` in `load.py`)
- [ ] Folder/plugin naming exception acknowledged or resolved for release (`EDMCModernOverlayDev` vs `EDMCModernOverlay`)

## Summary

- Changes:
- Testing:

