### PR TITLE
Fix/circle group bounds

### DIFF
--- a/EDMCOverlay/edmcoverlay.py
+++ b/EDMCOverlay/edmcoverlay.py
@@ -176,7 +176,8 @@ def normalise_legacy_payload(message: Mapping[str, Any]) -> Optional[Dict[str, A
         vector = _lookup("vector", "Vector")
         if shape_lower == "circle":
             payload["radius"] = _lookup("radius", "Radius")
-            payload["thickness"] = _lookup("thickness", "Thickness")
+            if "thickness" in msg or "Thickness" in msg:
+                payload["thickness"] = _lookup("thickness", "Thickness")
         elif shape_lower == "rect" and ("thickness" in msg or "Thickness" in msg):
             payload["thickness"] = _lookup("thickness", "Thickness")
         elif shape_lower == "vect":
@@ -330,9 +331,10 @@ class Overlay:
                 "x": int(x),
                 "y": int(y),
                 "radius": radius,
-                "thickness": None if thickness is _SHAPE_THICKNESS_UNSET else thickness,
                 "ttl": ttl,
             }
+            if thickness is not _SHAPE_THICKNESS_UNSET:
+                payload["thickness"] = thickness
             self._emit_payload(payload)
             return
 

--- a/docs/plans/2026-08-29-circle-group-bounds/design/detailed-design.md
+++ b/docs/plans/2026-08-29-circle-group-bounds/design/detailed-design.md
@@ -1,0 +1,122 @@
+# Detailed design: stable Fill-mode grouping for circle payloads
+
+## Overview
+
+This change aligns the geometry used to group circle payloads with the geometry
+used to render them. It removes apparent movement of a payload group when a
+circle payload refreshes alongside other BioScan payloads.
+
+The public `send_shape` API, the payload schema, and the circle paint command
+remain unchanged.
+
+## Detailed requirements
+
+1. A `LegacyItem` whose kind is `circle` contributes its full visual extent to
+   Fill-mode group bounds.
+2. A circle is defined by centre coordinates `(x, y)` and a positive `radius`.
+   Its untransformed logical bounds are `(x-radius, y-radius)` through
+   `(x+radius, y+radius)`.
+3. Transform metadata is applied to all four logical bounding-box corners
+   before calculating the enclosing group bounds.
+4. Messages, rectangles, vectors, and malformed payload behavior remain
+   unchanged.
+5. Unit coverage proves normal and transformed circle bounds and prevents the
+   regression that treated circles as centre points.
+
+## Architecture overview
+
+```mermaid
+flowchart TD
+    P[Circle LegacyItem] --> A[accumulate_group_bounds]
+    A -->|four transformed corners| B[GroupBounds]
+    B --> C[FillGroupingHelper]
+    C --> D[GroupTransform: bounds and anchor]
+    D --> E[Circle paint command]
+    E --> F[Stable grouped output]
+```
+
+## Components and interfaces
+
+### Circle bounds accumulation
+
+`accumulate_group_bounds(bounds, item, ...)` gains a circle-specific branch.
+It reads the logical `x`, `y`, and `radius`, derives the square bounds, passes
+all corners through the existing transform helper, and adds the enclosing
+minimum/maximum rectangle to `GroupBounds`.
+
+The branch uses the rectangle branch’s transform convention. This keeps its
+behavior correct for current translation metadata and future transform forms
+without duplicating transformation logic elsewhere.
+
+### Fill grouping integration
+
+`FillGroupingHelper.prepare()` requires no interface change. It already
+consumes `accumulate_group_bounds()` output to build `GroupTransform` values;
+correct bounds automatically produce a stable anchor and transform.
+
+### Rendering integration
+
+The circle renderer remains the visual authority. Its existing calculation
+uses exactly the same untransformed square geometry, so the grouping path and
+rendering path become consistent.
+
+## Data model
+
+Relevant circle item data:
+
+| Field | Meaning |
+| --- | --- |
+| `x`, `y` | Centre in legacy 1280×960 logical coordinates |
+| `radius` | Positive logical radius |
+| `__mo_transform__` | Optional transform metadata applied before group-bound aggregation |
+
+Derived bounds:
+
+| Edge | Formula |
+| --- | --- |
+| left | `x - radius` |
+| top | `y - radius` |
+| right | `x + radius` |
+| bottom | `y + radius` |
+
+## Error handling
+
+The legacy processor rejects invalid circles before storage. The bounds helper
+still retains its existing `TypeError`/`ValueError` containment so corrupted or
+legacy cached values do not interrupt rendering. A malformed circle therefore
+does not create a new failure mode or modify bounds.
+
+## Testing strategy
+
+- Add a pure unit test that a circle at `(x, y)` with radius `r` expands to the
+  expected square `GroupBounds`.
+- Add a unit test with transform metadata to prove corners, not the centre, are
+  transformed before aggregation.
+- Retain existing rectangle/vector/message tests as regression protection.
+- Run the focused unit module and then `make check`, which covers Ruff, mypy,
+  and the full pytest suite.
+
+## Phased delivery
+
+| Phase | Stages | Status |
+| --- | --- | --- |
+| 1. Bound contract tests | 1.1 Normal circle bounds; 1.2 transformed circle bounds | Planned |
+| 2. Bounds implementation | 2.1 Circle branch; 2.2 regression review | Planned |
+| 3. Validation | 3.1 Focused tests; 3.2 full project gate | Planned |
+
+## Appendix
+
+### Technology choices
+
+The existing pure Python bounds helper is the correct seam: it has no widget
+or socket lifecycle dependency, accepts injected text-measurement concerns for
+other payload kinds, and is already called by the Fill-mode grouping pipeline.
+
+### Alternative approaches considered
+
+- Expanding bounds in the renderer would leave grouping anchors wrong and
+  duplicate geometry ownership.
+- Modifying BioScan payload coordinates would be a compatibility break and
+  would still leave every other circle-producing plugin affected.
+- Disabling Fill-mode grouping would hide the symptom but regress established
+  group placement behavior.

--- a/docs/plans/2026-08-29-circle-group-bounds/idea-honing.md
+++ b/docs/plans/2026-08-29-circle-group-bounds/idea-honing.md
@@ -1,0 +1,17 @@
+# Requirements clarification
+
+## Established context
+
+- The change belongs on branch `fix/circle-group-bounds`.
+- `payload_transform.accumulate_group_bounds()` needs circle-aware bounds.
+- The renderer's existing circle geometry is the behavioral reference: centre
+  coordinates plus radius form a square bounding box.
+- A deterministic unit test is required because the affected helper is pure
+  apart from injected font dependencies.
+
+## Decision
+
+Proceed directly to the detailed design and implementation plan. Scope is
+limited to correcting circle bounds in the Fill-mode grouping path and proving
+the behavior with unit tests; it does not change the public `send_shape` API or
+the circle paint implementation.

--- a/docs/plans/2026-08-29-circle-group-bounds/implementation/execution-status.md
+++ b/docs/plans/2026-08-29-circle-group-bounds/implementation/execution-status.md
@@ -1,0 +1,28 @@
+# Circle group bounds — execution status
+
+| Phase | Stage | Status |
+| --- | --- | --- |
+| 1 | 1.1 Reconcile workspace and plan | Completed |
+| 2 | 2.1 Generate and execute Step 1 task | Completed |
+| 2 | 2.2 Generate and execute Step 2 task | Completed |
+| 2 | 2.3 Generate and execute Step 3 task | Completed |
+| 3 | 3.1 Final review and report | Completed |
+
+## Guardrails
+
+- Branch: `fix/circle-group-bounds`.
+- Do not commit, stage, push, reset, stash, or switch branches.
+- Preserve pre-existing unrelated work exactly as found.
+
+## Progress log
+
+- Step 1 task breakdown was generated and reviewed. A fresh implementation
+  context added the normal-circle regression test. The focused test has the
+  expected red result: the centre-point fallback reports min_x=100 rather
+  than the circle's required min_x=75. Step 2 will fix that behavior.
+- Step 2 added the narrow circle-bounds path and transformed-circle coverage.
+  The PyQt-enabled focused module is green: 5 passed in 0.14s. Step 3 will
+  perform the prescribed final validation without changing behavior.
+- Step 3 validation passed: focused bounds 5 passed; grouping, transform, and
+  renderer surfaces 33 passed; `make check` passed with Ruff, mypy (91 files),
+  and pytest (783 passed, 21 skipped). `git diff --check` also passed.

--- a/docs/plans/2026-08-29-circle-group-bounds/implementation/orchestration-prompt.md
+++ b/docs/plans/2026-08-29-circle-group-bounds/implementation/orchestration-prompt.md
@@ -1,0 +1,151 @@
+# Implementation Orchestration: stable Fill-mode grouping for circle payloads
+
+## Scope and authority
+
+Repository: `/home/jon/.local/share/EDMarketConnector/plugins/EDMCModernOverlay`
+
+Required branch: `fix/circle-group-bounds`
+
+Approved design: `docs/plans/2026-08-29-circle-group-bounds/design/detailed-design.md`
+
+Approved plan: `docs/plans/2026-08-29-circle-group-bounds/implementation/plan.md`
+
+Research and requirements: `docs/plans/2026-08-29-circle-group-bounds/{rough-idea.md,idea-honing.md,research/existing-code.md,summary.md}`
+
+Governing instructions: `AGENTS.md`
+
+Task artifacts: `docs/plans/2026-08-29-circle-group-bounds/implementation/tasks/`
+
+Status dashboard: `docs/plans/2026-08-29-circle-group-bounds/implementation/execution-status.md`
+
+Implement the approved plan only. The desired outcome is radius-aware group
+bounds for `LegacyItem(kind="circle")` in the Fill-mode grouping path, with
+tests proving normal and transformed circle geometry. Do not modify BioScan,
+the public `send_shape` API, legacy payload schema, or the circle paint command.
+
+Standing authority covers ordinary workspace-local edits to the intended source,
+tests, and plan execution records, along with non-destructive local tests,
+linters, type checks, and builds. No live game, EDMC, network, credentials,
+external service, installer, release, or package-install action is authorized.
+
+### Mandatory Git and workspace safety
+
+- **Do not commit, stage, push, amend, reset, checkout, switch, stash, clean,
+  restore, or otherwise alter Git history or the index.** The user explicitly
+  requires that all implementation changes remain uncommitted.
+- Before every edit, inspect `git status --short` and the scoped diff.
+- The workspace intentionally contains pre-existing uncommitted work. Preserve
+  it exactly, including `version.py`, `utils/payload_inspector.py`,
+  `tests/test_payload_inspector.py`,
+  `docs/plans/2026-08-29-payload-inspector-circle-preview/`, and any changes
+  outside this plan's circle-group-bounds paths.
+- Stop and ask the user if the current branch is not `fix/circle-group-bounds`,
+  an intended file overlaps an unexplained existing diff, the plan conflicts
+  with governing instructions, or a required validation cannot be made green.
+
+## Start and restart recovery
+
+Before editing on the initial run and every restart:
+
+1. Read every governing and approved artifact named above.
+2. Inspect `git status --short`, relevant diffs, `execution-status.md`, plan
+   checkboxes, task records, and validation logs.
+3. Reconcile completion claims against source and test evidence. Resume at the
+   first incomplete or unverified action; do not trust a stale status marker.
+4. Confirm that the target is the pure helper
+   `overlay_client/payload_transform.py::accumulate_group_bounds` and that
+   `overlay_client/render_surface.py` remains the visual geometry reference.
+
+Update `execution-status.md` before and after every plan step, code-task run,
+test, build, and demo. Use this exact progress line in the interactive session:
+
+`Step: [n]; Task: [id]; Phase: [planning|implementation|validation|demo]; Action: [completed/running action]; Next: [next action]`
+
+Provide a heartbeat at least every 60 seconds while a test or subagent is
+running.
+
+## Fresh-context task protocol
+
+Execute one approved plan step at a time. Do not overlap code-writing agents.
+
+For each plan step:
+
+1. In a **fresh, dedicated context/thread**, invoke one `code-task-generator`
+   agent to create only that step's task breakdown under
+   `implementation/tasks/stepNN/`. The main thread must review the generated
+   task for scope before implementation.
+2. For each generated task, invoke one **fresh, dedicated context/thread**
+   `code-assist` agent in auto mode. Each agent gets its own documentation and
+   log directory under `implementation/task-records/stepNN-taskMM/` and follows
+   strict RED → GREEN → REFACTOR.
+3. Run writing agents sequentially. Do not reuse an implementation agent's
+   context for a later task, step, remediation, or validation task.
+4. Require each task handoff to contain exactly:
+   `Status; Files changed; Validation commands/results; Decisions; Risks; Next exact action.`
+5. The user's no-commit rule overrides any subagent workflow that normally
+   commits. No subagent may stage or commit.
+
+Allow one initial implementation attempt and at most two fresh-context
+remediation attempts per task. Do not rerun an unchanged failing command more
+than once. Stop with evidence after the retry limit or 20 minutes without
+substantive progress.
+
+## Step-specific acceptance criteria
+
+### Step 1 — normal circle bounds
+
+- Add a focused unit test in `overlay_client/tests/test_payload_bounds.py`.
+- A circle centred at `(100, 200)` with radius `25` must contribute bounds
+  `(75, 175)` through `(125, 225)`.
+- The test must fail before implementation because the current generic fallback
+  contributes only the centre point.
+- Use unit tests only; no EDMC lifecycle or harness test is needed because the
+  behavior is deterministic helper logic.
+
+### Step 2 — transformed circle bounds
+
+- Add the smallest circle branch to `accumulate_group_bounds()`.
+- Derive `x-radius`, `y-radius`, `x+radius`, and `y+radius`; transform all four
+  corners through the existing local transform helper; aggregate their min/max.
+- Add a transformed-circle unit test that would fail if only the centre were
+  transformed.
+- Preserve the existing message, rectangle, vector, invalid-value, and paint
+  behavior. Do not touch the payload-inspector-preview changes already in the
+  working tree.
+
+### Step 3 — integration validation
+
+- Review the helper against the existing renderer's `x-radius`, `y-radius`,
+  `diameter=2*radius` calculation.
+- Verify the corrected helper is consumed by `FillGroupingHelper.prepare()`
+  without API changes.
+- Demonstrate locally through deterministic tests that repeated group-bound
+  preparation for an unchanged circle yields identical bounds; do not launch a
+  live game or EDMC instance.
+
+## Validation and reporting
+
+Use the existing environment; do not install dependencies. Run, in order:
+
+1. `overlay_client/.venv/bin/python -m pytest overlay_client/tests/test_payload_bounds.py`
+2. Relevant focused grouping/render tests discovered during the task.
+3. `make check`
+
+After each task, perform an independent main-thread review of its scoped diff,
+test results, unowned-file preservation, and documentation updates. Scan
+changed text artifacts and logs for secrets. Record exact commands and
+pass/fail/skip results in the task record and `execution-status.md`.
+
+## Stop conditions
+
+Stop and request user direction before any external write, credential or account
+access, live EDMC/game verification, dependency installation, destructive
+command, scope expansion, unresolved test failure, attempt to change a
+pre-existing unrelated file, or any Git staging/commit action.
+
+## Final report
+
+Report completed steps and their demos; files changed; generated task and
+handoff artifacts; exact validation commands/results; the fact that no commit
+was created; manual verification still recommended; and known limitations.
+Successful tests do not authorize a commit, push, release, or external action.

--- a/docs/plans/2026-08-29-circle-group-bounds/implementation/plan.md
+++ b/docs/plans/2026-08-29-circle-group-bounds/implementation/plan.md
@@ -1,0 +1,65 @@
+# Implementation plan: circle group bounds
+
+## Checklist
+
+- [ ] Step 1: Prove normal circle bounds.
+- [ ] Step 2: Implement transformed circle bounds and preserve all shapes.
+- [ ] Step 3: Validate the integrated Fill-mode grouping behavior.
+
+## Steps
+
+### Step 1: Prove normal circle bounds
+
+**Objective:** Add a deterministic unit test that defines the circle-to-bounds
+contract before changing production code.
+
+**Implementation guidance:** In `overlay_client/tests/test_payload_bounds.py`,
+construct a `LegacyItem(kind="circle")` with centre coordinates and radius,
+then call `accumulate_group_bounds()` using stable injected dependencies.
+Assert that the bounds equal the circle’s enclosing square, not its centre
+point.
+
+**Test requirements:** The new test must fail against the current generic
+fallback and use no PyQt event loop or EDMC harness lifecycle.
+
+**Integration:** Establishes the shared geometry contract consumed by
+`FillGroupingHelper.prepare()`.
+
+**Demo:** The test demonstrates that a circle at `(100, 200)` with radius `25`
+contributes `(75, 175)` through `(125, 225)` to its group.
+
+### Step 2: Implement transformed circle bounds and preserve all shapes
+
+**Objective:** Add the circle branch to `accumulate_group_bounds()` and prove
+that transform metadata is applied consistently with rectangles.
+
+**Implementation guidance:** Derive four logical corners from centre/radius,
+transform each through the existing local transform function, and update the
+enclosing rectangle. Keep the rectangle/vector/message branches unchanged.
+
+**Test requirements:** Add a transformed-circle test whose expected bounds
+would differ if only the centre were transformed. Run
+`overlay_client/.venv/bin/python -m pytest overlay_client/tests/test_payload_bounds.py`.
+
+**Integration:** The existing Fill grouping helper will consume the corrected
+bounds without new API or renderer wiring.
+
+**Demo:** A transformed circle yields a stable, radius-aware group transform
+while its rendered footprint remains unchanged.
+
+### Step 3: Validate the integrated Fill-mode grouping behavior
+
+**Objective:** Validate the regression fix across the grouping and rendering
+surfaces without changing public payload behavior.
+
+**Implementation guidance:** Review the changed helper for equivalence with
+the renderer’s `x-radius`, `y-radius`, and diameter model. Do not alter
+BioScan, `send_shape`, or circle paint commands.
+
+**Test requirements:** Run the focused bounds module, the relevant group
+transform/render-surface tests, and `make check`.
+
+**Integration:** Confirms that existing Fill-mode `GroupTransform` construction
+receives complete circle geometry and that all repository checks remain green.
+
+**Demo:** Repeated BioScan circle refreshes no longer reposition its group.

--- a/docs/plans/2026-08-29-circle-group-bounds/implementation/task-records/step01-task01/context.md
+++ b/docs/plans/2026-08-29-circle-group-bounds/implementation/task-records/step01-task01/context.md
@@ -1,0 +1,23 @@
+# Step 1 / Task 1 context
+
+## Scope
+
+Add only the normal-circle regression test in
+`overlay_client/tests/test_payload_bounds.py`. Production code is intentionally
+unchanged in this task.
+
+## Contract
+
+For a circle with centre `(100, 200)` and radius `25`, Fill-mode group bounds
+must cover `(75, 175)` through `(125, 225)`.
+
+## Dependency map
+
+`LegacyItem` → `payload_transform.accumulate_group_bounds()` → `GroupBounds`.
+The helper currently routes circles through the generic centre-point fallback,
+so the test is intentionally red until Step 2 adds circle-specific bounds.
+
+## Test selection
+
+This is a deterministic pure-helper unit test. It does not require an EDMC
+lifecycle, socket, renderer, or BioScan integration harness.

--- a/docs/plans/2026-08-29-circle-group-bounds/implementation/task-records/step01-task01/plan.md
+++ b/docs/plans/2026-08-29-circle-group-bounds/implementation/task-records/step01-task01/plan.md
@@ -1,0 +1,13 @@
+# Step 1 / Task 1 plan
+
+- [x] Inspect the approved design, bounds helper, and existing unit-test style.
+- [x] Add one untransformed circle-bounds regression test.
+- [x] Run the focused PyQt-enabled module and capture the expected red result.
+- [x] Record the red-baseline cause and hand off Step 2.
+
+## Test scenario
+
+Given `LegacyItem(kind="circle")` with `x=100`, `y=200`, and `radius=25`,
+after `accumulate_group_bounds()` the bounds must have minimum `(75, 175)` and
+maximum `(125, 225)`. The current generic fallback is expected to produce the
+centre `(100, 200)` instead.

--- a/docs/plans/2026-08-29-circle-group-bounds/implementation/task-records/step01-task01/progress.md
+++ b/docs/plans/2026-08-29-circle-group-bounds/implementation/task-records/step01-task01/progress.md
@@ -1,0 +1,25 @@
+# Step 1 / Task 1 progress
+
+## Setup
+
+- Auto-mode task execution in a fresh context.
+- Read the approved design, task breakdown, repository instructions, README,
+  test module, and current bounds helper.
+- Preserved the existing dirty worktree and no Git mutation commands are used.
+
+## TDD
+
+- RED: Added the normal-circle bounds contract test before any production
+  change.
+- `PYQT_TESTS=1 overlay_client/.venv/bin/python -m pytest
+  overlay_client/tests/test_payload_bounds.py` produced `1 failed, 3 passed`.
+  The intentional failure is `test_circle_bounds_cover_full_radius`: the
+  current generic fallback reports `min_x=100.0`, not the required `75.0`.
+  Full output is retained in `logs/focused-red.log`.
+
+## Handoff
+
+Step 2 should add the circle-specific branch in
+`payload_transform.accumulate_group_bounds()`, deriving the four corners from
+the centre and radius before applying transform metadata. No production change
+was made in this task.

--- a/docs/plans/2026-08-29-circle-group-bounds/implementation/task-records/step02-task01/context.md
+++ b/docs/plans/2026-08-29-circle-group-bounds/implementation/task-records/step02-task01/context.md
@@ -1,0 +1,20 @@
+# Step 2 / Task 1 context
+
+## Scope
+
+Add the minimal circle-specific `accumulate_group_bounds()` branch and one
+transformed-circle unit test. No renderer, API, grouping-helper, or unrelated
+worktree changes are in scope.
+
+## Contract and dependency map
+
+`LegacyItem(kind="circle")` flows through
+`payload_transform.accumulate_group_bounds()` to `GroupBounds`, which
+`FillGroupingHelper.prepare()` consumes. The renderer defines a circle as the
+square enclosing its centre and radius. Bounds must transform all four square
+corners through the existing local helper before aggregation.
+
+## Test choice
+
+This is deterministic, pure geometry under the existing PyQt-dependent test
+module. It requires a unit test, not a lifecycle harness.

--- a/docs/plans/2026-08-29-circle-group-bounds/implementation/task-records/step02-task01/plan.md
+++ b/docs/plans/2026-08-29-circle-group-bounds/implementation/task-records/step02-task01/plan.md
@@ -1,0 +1,12 @@
+# Step 2 / Task 1 plan
+
+- [x] Inspect approved design, renderer geometry, rectangle convention, and Step 1 red baseline.
+- [x] Add transformed-circle contract test and record its red result.
+- [x] Add the narrow circle bounds branch using transformed extent corners.
+- [x] Run the focused PyQt-enabled bounds module green and `git diff --check`.
+
+## Test scenarios
+
+- Untransformed centre `(100, 200)`, radius `25` spans `(75, 175)` to `(125, 225)`.
+- With scale `(2, 0.5)` and offset `(10, -20)`, the same circle spans `(160,
+  67.5)` to `(260, 92.5)` after transforming all extent corners.

--- a/docs/plans/2026-08-29-circle-group-bounds/implementation/task-records/step02-task01/progress.md
+++ b/docs/plans/2026-08-29-circle-group-bounds/implementation/task-records/step02-task01/progress.md
@@ -1,0 +1,36 @@
+# Step 2 / Task 1 progress
+
+## Setup
+
+- Auto-mode execution in a fresh implementation context.
+- Read the approved task, detailed design, renderer geometry, bounds helper,
+  Step 1 task record, repository README, and applicable `code-assist` SOP.
+- No `CODEASSIST.md` was present. Existing unrelated worktree changes are
+  preserved, and no Git index or history operations are used.
+
+## TDD
+
+- RED: after adding the transformed regression, `PYQT_TESTS=1
+  overlay_client/.venv/bin/python -m pytest
+  overlay_client/tests/test_payload_bounds.py` reported `2 failed, 3 passed`.
+  The normal circle still reported `min_x=100.0` rather than `75.0`; the
+  transformed circle reported the centre `min_x=210.0` rather than `160.0`.
+- GREEN: added the `circle` branch adjacent to the existing rectangle branch.
+  It derives the centre-plus/minus-radius square, transforms each corner with
+  the existing local helper, and aggregates its enclosing rectangle.
+- `PYQT_TESTS=1 overlay_client/.venv/bin/python -m pytest
+  overlay_client/tests/test_payload_bounds.py` passed: `5 passed in 0.14s`.
+- `git diff --check` passed with no output.
+
+## Decision
+
+The branch deliberately mirrors the rectangle transform convention instead of
+adding new transform logic. Invalid numeric values remain contained by the
+function's existing `TypeError`/`ValueError` handler.
+
+## Handoff
+
+Step 3 should perform the planned integration and repository-wide validation.
+This task intentionally did not run broad checks or modify renderer, API,
+grouping-helper, or unrelated worktree files. No changes were committed or
+staged.

--- a/docs/plans/2026-08-29-circle-group-bounds/implementation/tasks/step01/task-01-prove-normal-circle-bounds.code-task.md
+++ b/docs/plans/2026-08-29-circle-group-bounds/implementation/tasks/step01/task-01-prove-normal-circle-bounds.code-task.md
@@ -1,0 +1,68 @@
+# Task: Prove Normal Circle Bounds
+
+## Description
+Add a focused regression test that defines the Fill-mode grouping geometry for a
+legacy circle payload before production code changes. The test must prove that
+the circle contributes its enclosing square to `GroupBounds`, rather than the
+centre point currently contributed by the generic fallback.
+
+## Background
+`FillGroupingHelper.prepare()` rebuilds group bounds from `LegacyItem` values
+through `payload_transform.accumulate_group_bounds()`. Circle rendering already
+uses a centre-plus-radius model, but the bounds helper currently has explicit
+message, rectangle, and vector cases only. A circle therefore falls through to
+the generic point case. This test anchors the expected untransformed geometry
+so the subsequent implementation can be behavior-scoped and verified.
+
+## Reference Documentation
+**Required:**
+- Design: `docs/plans/2026-08-29-circle-group-bounds/design/detailed-design.md`
+
+**Additional References (if relevant to this task):**
+- `docs/plans/2026-08-29-circle-group-bounds/implementation/plan.md` (Step 1 requirements and demo)
+- `docs/plans/2026-08-29-circle-group-bounds/research/existing-code.md` (current fallback and renderer contract)
+- `overlay_client/tests/test_payload_bounds.py` (existing bounds-test patterns)
+- `overlay_client/payload_transform.py` (`accumulate_group_bounds()` contract)
+
+**Note:** You MUST read the detailed design document before beginning implementation. Read additional references as needed for context.
+
+## Technical Requirements
+1. Update only `overlay_client/tests/test_payload_bounds.py` for this task; do not change production code.
+2. Construct a `LegacyItem` with `kind="circle"`, centre `(100, 200)`, and positive radius `25`, using the same test fixture style as the module.
+3. Call `payload_transform.accumulate_group_bounds()` with deterministic injected dependencies and assert valid bounds of `(75, 175)` through `(125, 225)`.
+4. Keep the test independent of EDMC lifecycle hooks and of a running PyQt event loop beyond the module's established test environment.
+5. The new test must fail against the current production fallback, documenting the red baseline for the Step 2 implementation task.
+6. Preserve all existing tests and existing uncommitted workspace changes; do not stage, commit, push, reset, stash, or switch branches.
+
+## Dependencies
+- The approved detailed design and implementation plan cited above.
+- The existing `GroupBounds`, `LegacyItem`, and `accumulate_group_bounds()` test interfaces.
+- A test environment with `PYQT_TESTS=1`; this test module intentionally skips when that flag is absent.
+
+## Implementation Approach
+1. Read the detailed design, current bounds test module, and bounds helper to confirm the established import and fixture patterns.
+2. Add one clearly named circle-bounds test beside the current bounds tests, creating a circle item without transform metadata.
+3. Accumulate its bounds and assert every min/max edge using `pytest.approx` where consistent with module conventions.
+4. Run the focused test module with `PYQT_TESTS=1` and record that the new assertion fails only because circles currently use the generic centre-point fallback.
+
+## Acceptance Criteria
+
+1. **Circle Bounds Contract Is Explicit**
+   - Given a `LegacyItem` with `kind="circle"`, `x=100`, `y=200`, and `radius=25`
+   - When `accumulate_group_bounds()` processes the item without transform metadata
+   - Then the test asserts valid group bounds with `min_x=75`, `min_y=175`, `max_x=125`, and `max_y=225`.
+
+2. **Regression Is Reproducible Before the Fix**
+   - Given the production bounds helper has not been changed in this task
+   - When the focused test is run with `PYQT_TESTS=1`
+   - Then the new circle-bounds assertion fails against the current centre-point fallback while no unrelated test behavior is changed.
+
+3. **Focused Unit-Test Scope**
+   - Given the new test runs in `overlay_client/tests/test_payload_bounds.py`
+   - When it exercises the circle contract
+   - Then it requires no EDMC harness lifecycle, socket, renderer, or BioScan integration setup.
+
+## Metadata
+- **Complexity**: Low
+- **Labels**: Circle, Fill-Mode, Group-Bounds, Regression-Test, PyQt
+- **Required Skills**: Python, pytest, geometric coordinate reasoning, regression-test design

--- a/docs/plans/2026-08-29-circle-group-bounds/implementation/tasks/step02/task-01-accumulate-transformed-circle-bounds.code-task.md
+++ b/docs/plans/2026-08-29-circle-group-bounds/implementation/tasks/step02/task-01-accumulate-transformed-circle-bounds.code-task.md
@@ -1,0 +1,128 @@
+# Task: Accumulate Transformed Circle Bounds
+
+## Description
+Implement the smallest circle-specific path in
+`payload_transform.accumulate_group_bounds()` so Fill-mode grouping uses the
+same full circle footprint as the renderer. Extend the focused unit coverage
+with a transformed-circle case that proves all four extent corners, rather than
+only the centre, participate in bounds aggregation.
+
+## Background
+Step 1 added a deliberately red regression test: a circle centred at `(100,
+200)` with radius `25` must contribute `(75, 175)` through `(125, 225)` to
+`GroupBounds`. The current generic fallback records only the centre point.
+
+`overlay_client/render_surface.py` defines the visual contract by expanding a
+circle to `left=x-radius`, `top=y-radius`, and a diameter of `2 * radius`.
+`accumulate_group_bounds()` already follows the required transform convention
+for rectangles: transform each of four logical corners with its local
+`transform_point()` helper, then aggregate the transformed min/max rectangle.
+The circle branch must use that same convention so `FillGroupingHelper.prepare()`
+gets stable geometry without changes to public payloads or rendering.
+
+## Reference Documentation
+**Required:**
+- Design: `docs/plans/2026-08-29-circle-group-bounds/design/detailed-design.md`
+
+**Additional References (if relevant to this task):**
+- `docs/plans/2026-08-29-circle-group-bounds/implementation/plan.md` (Step 2 requirements and demo)
+- `docs/plans/2026-08-29-circle-group-bounds/research/existing-code.md` (renderer contract and current fallback)
+- `docs/plans/2026-08-29-circle-group-bounds/implementation/task-records/step01-task01/progress.md` (intentional red baseline)
+- `overlay_client/payload_transform.py` (`accumulate_group_bounds()` rectangle branch)
+- `overlay_client/render_surface.py` (circle `x-radius`, `y-radius`, `2*radius` geometry)
+- `overlay_client/tests/test_payload_bounds.py` (current normal-circle regression and test style)
+
+**Note:** You MUST read the detailed design document before beginning
+implementation. Read additional references as needed for context.
+
+## Technical Requirements
+1. Change only `overlay_client/payload_transform.py` and
+   `overlay_client/tests/test_payload_bounds.py`, plus the task's own record
+   files under `docs/plans/2026-08-29-circle-group-bounds/implementation/task-records/step02-task01/`.
+2. Add an `item.kind == "circle"` branch in `accumulate_group_bounds()` before
+   the generic fallback. Read `x`, `y`, and `radius` using the function's
+   current logical/raw fallback convention.
+3. Derive the circle's four logical square corners:
+   `(x-radius, y-radius)`, `(x+radius, y-radius)`,
+   `(x-radius, y+radius)`, and `(x+radius, y+radius)`.
+4. Pass every derived corner through the existing local `transform_point()`
+   helper, then call `bounds.update_rect()` with the transformed min/max
+   values. Do not duplicate or replace the transform-metadata implementation.
+5. Keep the message, rectangle, vector, generic fallback, exception handling,
+   `determine_group_anchor()`, legacy payload schema, `send_shape` API, and
+   circle paint commands unchanged.
+6. Retain Step 1's untransformed test and add one transformed-circle test. Use
+   non-uniform transform metadata (for example scale and offset) and assert
+   all four final bounds. Its expected bounds must differ from a transformed
+   centre point, proving radius extents were transformed.
+7. Preserve all existing uncommitted work, including `version.py`,
+   `utils/payload_inspector.py`, `tests/test_payload_inspector.py`, and
+   `docs/plans/2026-08-29-payload-inspector-circle-preview/`. Do not stage,
+   commit, push, amend, reset, checkout, switch, stash, clean, restore, or
+   otherwise alter Git history or the index.
+
+## Dependencies
+- Step 1's normal-circle contract is present and intentionally red before this
+  production change.
+- `GroupBounds`, `LegacyItem`, and `apply_transform_meta_to_point()` remain the
+  existing interfaces; no new public API is needed.
+- `PYQT_TESTS=1` is required for `overlay_client/tests/test_payload_bounds.py`;
+  the module otherwise skips by design.
+
+## Implementation Approach
+1. Inspect the current scoped diff and confirm Step 1's test is the only
+   pre-existing change in the target test module. Read the approved design and
+   the rectangle branch before editing.
+2. Add the narrow `circle` branch beside the existing explicit shape branches.
+   Convert the three numeric fields inside the existing `try` containment,
+   transform all four extent corners with `transform_point()`, and aggregate
+   their enclosing rectangle.
+3. Add a focused transformed-circle test. A circle at `(100, 200)` with radius
+   `25` and `__mo_transform__={"scale": {"x": 2.0, "y": 0.5}, "offset":
+   {"x": 10.0, "y": -20.0}}` should assert bounds `(160, 67.5)` through
+   `(260, 92.5)`. Those values demonstrate transformed extents, not merely a
+   transformed centre `(210, 80)`.
+4. Run the focused PyQt-enabled bounds module. First use the existing red
+   baseline as TDD evidence; after the branch and test are in place, it must be
+   green. Record exact commands and results in the task record. Run only
+   scoped, non-destructive checks during this task; Step 3 owns repository-wide
+   validation.
+
+## Acceptance Criteria
+
+1. **Normal Circle Contract Turns Green**
+   - Given Step 1's circle centred at `(100, 200)` with radius `25`
+   - When `accumulate_group_bounds()` processes it without transform metadata
+   - Then `GroupBounds` is valid with minimum `(75, 175)` and maximum
+     `(125, 225)`.
+
+2. **Transformed Extents Are Aggregated**
+   - Given a circle centred at `(100, 200)` with radius `25` and metadata with
+     `scale=(2.0, 0.5)` and `offset=(10.0, -20.0)`
+   - When `accumulate_group_bounds()` processes it
+   - Then its transformed bounds are minimum `(160, 67.5)` and maximum
+     `(260, 92.5)`, rather than a zero-area transformed centre point.
+
+3. **Existing Shape Behavior Is Preserved**
+   - Given messages, rectangles, vectors, and unsupported kinds continue
+     through their existing branches
+   - When the focused bounds module runs
+   - Then their existing tests still pass without source changes to those
+     branches.
+
+4. **Focused Unit Validation Is Green**
+   - Given the implementation and both circle regression tests are complete
+   - When `PYQT_TESTS=1 overlay_client/.venv/bin/python -m pytest
+     overlay_client/tests/test_payload_bounds.py` runs
+   - Then the command passes, including normal and transformed circle cases.
+
+5. **Workspace Safety Is Maintained**
+   - Given the repository began with unrelated uncommitted work
+   - When this task completes
+   - Then only its allowed source, test, and task-record paths have changed;
+     no Git index or history operation was performed.
+
+## Metadata
+- **Complexity**: Medium
+- **Labels**: Circle, Fill-Mode, Group-Bounds, Transform, Regression-Test, PyQt
+- **Required Skills**: Python, pytest, geometric coordinate reasoning, TDD

--- a/docs/plans/2026-08-29-circle-group-bounds/implementation/tasks/step03/task-01-validate-circle-group-bounds.code-task.md
+++ b/docs/plans/2026-08-29-circle-group-bounds/implementation/tasks/step03/task-01-validate-circle-group-bounds.code-task.md
@@ -1,0 +1,115 @@
+# Task: Validate Integrated Circle Group Bounds
+
+## Description
+Perform the final, validation-only check of the circle group-bounds regression
+fix. Confirm that the focused bounds contract, its grouping/rendering
+integration surfaces, and the repository-wide quality gate remain green. This
+task must not change production or test behavior.
+
+## Background
+Steps 1 and 2 established and implemented the geometry contract: a circle is
+bounded by its centre plus/minus radius, and all four resulting corners use the
+same transform path as rectangles. The focused PyQt-enabled bounds module is
+already green after the narrow `accumulate_group_bounds()` change. This final
+step verifies that the implementation remains aligned with the existing
+renderer model (`x-radius`, `y-radius`, `2 * radius`) and that the surrounding
+Fill-mode/group-transform and rendering test surfaces remain healthy.
+
+The target worktree is intentionally dirty. In particular, unrelated payload
+inspector, version, and prior planning work must be preserved exactly as found.
+
+## Reference Documentation
+**Required:**
+- Design: `docs/plans/2026-08-29-circle-group-bounds/design/detailed-design.md`
+
+**Additional References (if relevant to this task):**
+- `docs/plans/2026-08-29-circle-group-bounds/implementation/plan.md` (Step 3 requirements)
+- `docs/plans/2026-08-29-circle-group-bounds/implementation/task-records/step01-task01/progress.md` (red-baseline evidence)
+- `docs/plans/2026-08-29-circle-group-bounds/implementation/task-records/step02-task01/progress.md` (implementation and focused-green evidence)
+- `overlay_client/payload_transform.py` (`accumulate_group_bounds()` circle branch)
+- `overlay_client/render_surface.py` (existing circle renderer geometry)
+- `overlay_client/tests/test_payload_bounds.py`, `overlay_client/tests/test_grouping_helper.py`, `overlay_client/tests/test_group_transform.py`, and `overlay_client/tests/test_render_surface_mixin.py`
+
+**Note:** You MUST read the detailed design document before beginning
+validation. Read additional references as needed for context.
+
+## Technical Requirements
+1. This is validation-only: do not edit production source, tests, task records,
+   execution status, or planning documents.
+2. Before validation, inspect the scoped diff for
+   `overlay_client/payload_transform.py` and
+   `overlay_client/tests/test_payload_bounds.py`. Confirm the circle branch
+   derives `x +/- radius` and `y +/- radius`, transforms all four corners, and
+   does not alter existing message, rectangle, vector, or generic-fallback
+   behavior.
+3. Run exactly these validation commands from the repository root:
+   - `PYQT_TESTS=1 overlay_client/.venv/bin/python -m pytest overlay_client/tests/test_payload_bounds.py`
+   - `PYQT_TESTS=1 overlay_client/.venv/bin/python -m pytest overlay_client/tests/test_grouping_helper.py overlay_client/tests/test_group_transform.py overlay_client/tests/test_render_surface_mixin.py`
+   - `make check`
+4. Run `git diff --check`, inspect `git diff --check` output, and inspect
+   `git status --short` plus the scoped diff after validation. These are
+   read-only safety checks only.
+5. Preserve all existing uncommitted work, including `version.py`,
+   `utils/payload_inspector.py`, `tests/test_payload_inspector.py`, and
+   `docs/plans/2026-08-29-payload-inspector-circle-preview/`.
+6. Do not stage, commit, push, amend, reset, checkout, switch, stash, clean,
+   restore, rebase, merge, or otherwise alter Git index, history, branches, or
+   unrelated files. If a scoped defect is discovered, stop and report it in the
+   handoff; do not fix it in this validation task.
+7. Document each command's exact pass/fail/skip result in the final handoff,
+   along with the scoped-diff and worktree inspection outcome. Do not create or
+   update files to record that information.
+
+## Dependencies
+- Step 1's normal-circle regression test and Step 2's transformed-circle test
+  and implementation are present.
+- The local `overlay_client/.venv` has the PyQt-enabled test environment.
+- `make check` remains the repository's lint, typecheck, and full-test gate.
+
+## Implementation Approach
+1. Read the approved design, Step 3 plan, and Step 1/2 progress records, then
+   inspect the target source/test diff against the renderer's established
+   square-footprint model.
+2. Run the focused bounds module first, followed by the grouping,
+   group-transform, and render-surface modules, then the repository-wide
+   `make check` gate.
+3. Perform the whitespace, scoped-diff, and worktree safety checks after the
+   commands complete. Return concise evidence; make no edits.
+
+## Acceptance Criteria
+
+1. **Circle Regression Contract Is Green**
+   - Given the Step 2 circle bounds implementation is present
+   - When `PYQT_TESTS=1 overlay_client/.venv/bin/python -m pytest overlay_client/tests/test_payload_bounds.py` runs
+   - Then the normal and transformed circle-bounds cases pass.
+
+2. **Grouping and Rendering Surfaces Remain Green**
+   - Given Fill grouping consumes `accumulate_group_bounds()` and the renderer
+     remains the visual authority
+   - When the specified grouping, group-transform, and render-surface test
+     modules run with `PYQT_TESTS=1`
+   - Then they pass without changes to public payloads or circle paint commands.
+
+3. **Repository Quality Gate Is Green**
+   - Given the scoped implementation is complete
+   - When `make check` runs
+   - Then linting, type checking, and the configured test suite pass, with any
+     skips reported exactly as emitted by the command.
+
+4. **Scoped Change and Worktree Safety Are Confirmed**
+   - Given the validation task began with unrelated uncommitted work
+   - When the final scoped diff, `git diff --check`, and `git status --short`
+     are inspected
+   - Then the circle changes remain limited to the approved source/test paths,
+     no whitespace errors appear, and unrelated work remains preserved.
+
+5. **Validation Does Not Expand Scope**
+   - Given the task is final validation only
+   - When a potential issue outside the approved circle-bounds scope is found
+   - Then it is reported without modifying production code, tests, records, or
+     Git state.
+
+## Metadata
+- **Complexity**: Low
+- **Labels**: Validation, Circle, Fill-Mode, Group-Bounds, Regression-Test, PyQt
+- **Required Skills**: Python, pytest, static-analysis interpretation, scoped-diff review

--- a/docs/plans/2026-08-29-circle-group-bounds/research/existing-code.md
+++ b/docs/plans/2026-08-29-circle-group-bounds/research/existing-code.md
@@ -1,0 +1,40 @@
+# Existing-code findings
+
+## Data flow
+
+```mermaid
+flowchart LR
+    A[BioScan send_shape circle] --> B[Legacy payload processor]
+    B --> C[LegacyItem kind=circle]
+    C --> D[FillGroupingHelper.prepare]
+    D --> E[accumulate_group_bounds]
+    E --> F[GroupTransform bounds and anchor]
+    F --> G[Circle paint command]
+```
+
+## Observations
+
+- The legacy processor validates positive circle radius and thickness, then
+  stores the payload as `LegacyItem(kind="circle")`.
+- The circle paint command expands centre coordinates into a square:
+  `left=x-radius`, `top=y-radius`, `width=height=2*radius`.
+- `FillGroupingHelper.prepare()` rebuilds group bounds every render pass using
+  `accumulate_group_bounds()` and uses those bounds to choose the group anchor
+  and generate a `GroupTransform`.
+- `accumulate_group_bounds()` has explicit paths for message, rectangle, and
+  vector items. Circles currently fall through to the generic point path,
+  contributing only `(x, y)`.
+
+## Consequence
+
+The group transformation is based on geometry that differs from the painted
+circle. Whenever the group membership or active payload set changes on a
+refresh, its derived bounds and anchor can change, producing visible movement.
+
+## Constraints
+
+- Circle renderer behavior is the contract; do not change its coordinate model.
+- Bounds must support transform metadata, so all four corners must be
+  transformed before calculating min/max, as rectangles already do.
+- Invalid values remain filtered by the legacy processor; group-bounds code
+  should remain defensive and avoid raising for malformed cached data.

--- a/docs/plans/2026-08-29-circle-group-bounds/rough-idea.md
+++ b/docs/plans/2026-08-29-circle-group-bounds/rough-idea.md
@@ -1,0 +1,6 @@
+# Circle group bounds
+
+Fix grouped BioScan circle payloads so their radius contributes to Fill-mode
+group bounds. The current grouping path records only the circle centre, while
+the renderer draws the full diameter. That geometry mismatch causes the group
+to jump when payloads refresh.

--- a/docs/plans/2026-08-29-circle-group-bounds/summary.md
+++ b/docs/plans/2026-08-29-circle-group-bounds/summary.md
@@ -1,0 +1,20 @@
+# Circle group bounds plan summary
+
+## Created artifacts
+
+- `rough-idea.md`: problem statement.
+- `idea-honing.md`: confirmed scope and planning decision.
+- `research/existing-code.md`: data-flow and root-cause evidence.
+- `design/detailed-design.md`: standalone design for radius-aware group bounds.
+- `implementation/plan.md`: incremental test-driven execution plan.
+
+## Design summary
+
+The Fill-mode grouping helper will treat circles as their full square visual
+extent after applying transform metadata to all four corners. This makes group
+bounds match the existing renderer and stabilizes group anchoring across
+payload refreshes.
+
+## Next step
+
+Implement the plan starting with the normal circle-bounds regression test.

--- a/docs/plans/2026-08-29-circle-thickness-pixel-width/design/detailed-design.md
+++ b/docs/plans/2026-08-29-circle-thickness-pixel-width/design/detailed-design.md
@@ -1,0 +1,80 @@
+# Detailed design: pixel-width circle strokes
+
+## Overview
+
+Circle geometry remains part of the scaleable 1280×960 legacy canvas, but an
+explicit circle `thickness` becomes a Qt logical-pixel pen width. This makes
+`thickness=1` match the established thin legacy-vector stroke at every Fit or
+Fill scale. Rectangles retain their existing logical-thickness behavior.
+
+## Detailed requirements
+
+1. A valid circle payload continues to require a positive integer `thickness`.
+2. Circle `thickness=1` resolves to `QPen.width() == 1` when group scales are
+   0.5, 1.0, and 2.0.
+3. Other positive circle thicknesses resolve to their rounded integer pixel
+   widths without Fit/Fill multiplication.
+4. Explicit rectangle thickness remains `round(thickness * group_scale)`,
+   clamped to at least one pixel.
+5. Circle position, radius, Fill grouping, transform metadata, opacity,
+   colors, joins, and public `send_shape` arguments remain unchanged.
+6. Existing invalid/missing-thickness handling remains unchanged.
+
+## Architecture overview
+
+```mermaid
+flowchart TD
+  S[_StrokeWidthSpec] --> L[explicit_logical_width]
+  S --> P[explicit_pixel_width]
+  L --> R[round width × viewport scale]
+  P --> Q[round width]
+  R --> K[clamp to >= 1 and QPen.setWidth]
+  Q --> K
+  Rect[Rectangle command] --> L
+  Circle[Circle command] --> P
+```
+
+`_StrokeWidthSpec` is the internal policy seam. Add an
+`explicit_pixel_width: Optional[float]` field beside the existing logical
+field. `_build_bounded_shape_command()` resolves it first, because it is an
+intentional supplied width, then falls back to the logical policy, then to a
+shape default pixel width. Invalid values are already excluded by payload
+processing; defensive conversion failure should retain the existing no-crash
+behavior rather than introduce a new API error.
+
+## Components and interfaces
+
+| Component | Change |
+| --- | --- |
+| `_StrokeWidthSpec` | Represent explicit pixel and explicit logical policies separately. |
+| `_build_bounded_shape_command()` | Select and clamp the policy result before copying the pen and calling `setWidth`. |
+| `_build_circle_command()` | Pass the validated payload thickness as an explicit pixel width. |
+| `_build_rect_command()` | No behavior change; retain explicit logical width and existing default policy. |
+| Tests | Split the current shared shape-scale test so rect and circle contracts are independently explicit. |
+
+## Error handling
+
+The legacy processor remains the validation boundary: circles with absent,
+zero, negative, or non-numeric thickness are rejected before rendering. The
+renderer still clamps any resolved positive path to one pixel and must not
+raise if a direct/internal test supplies an unexpected value.
+
+## Testing strategy
+
+- Unit test circle `thickness=1` at group scales 0.5, 1.0, and 2.0, asserting
+  a one-pixel pen each time.
+- Unit test another circle value such as 3 at scale 2.0 resolves to 3, proving
+  this is unscaled rather than merely a special case for one.
+- Preserve/add rectangle parameterization asserting `thickness=2` resolves to
+  1, 2, and 4 at scales 0.5, 1.0, and 2.0.
+- Run the focused render-surface module with `PYQT_TESTS=1`, then `make check`.
+
+## Alternatives considered
+
+- **Scale both vectors and circles:** rejected because it changes the visual
+  contract of established vectors and would not make the compared strokes
+  match.
+- **Treat every bounded shape as pixels:** rejected because it silently
+  changes rectangle behavior.
+- **Special-case `thickness=1` only:** rejected because API units would be
+  inconsistent and `thickness=2` would still change with viewport scale.

--- a/docs/plans/2026-08-29-circle-thickness-pixel-width/idea-honing.md
+++ b/docs/plans/2026-08-29-circle-thickness-pixel-width/idea-honing.md
@@ -1,0 +1,21 @@
+# Requirements decisions
+
+## Question
+
+Which payloads should change stroke semantics?
+
+## Answer
+
+Only `shape="circle"`. The request is to make circle `thickness=1` visually
+match the legacy vector line on the left of the supplied comparison image.
+Rectangles keep their existing logical-width, viewport-scaled behavior.
+
+## Question
+
+What does a circle thickness value mean after the change?
+
+## Answer
+
+It is an integer logical Qt pixel width, clamped to at least one pixel. It is
+not multiplied by Fit/Fill viewport scale. Qt continues to handle the display
+device-pixel ratio consistently with the legacy vector line.

--- a/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/execution-status.md
+++ b/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/execution-status.md
@@ -1,0 +1,35 @@
+# Pixel-width circle strokes — execution status
+
+| Phase | Stage | Status |
+| --- | --- | --- |
+| 1 | 1.1 Reconcile workspace, plan, and guardrails | Completed |
+| 2 | 2.1 Generate and execute Step 1 task | Completed |
+| 2 | 2.2 Generate and execute Step 2 task | Completed |
+| 2 | 2.3 Generate and execute Step 3 task | Completed |
+| 3 | 3.1 Final review and handoff | Completed |
+
+## Guardrails
+
+- Use the currently checked-out branch; do not switch branches.
+- Never commit, stage, push, amend, reset, restore, stash, clean, checkout,
+  rebase, merge, or otherwise alter Git history or the index.
+- Preserve all work already present before execution, including the uncommitted
+  plan artifacts in this directory.
+
+## Progress log
+
+- Reconciliation completed: the worktree contains only this uncommitted plan
+  directory, `git diff --check` passed, and no implementation task or record
+  exists yet. Step 1 task generation is next.
+- Step 1 established the red contract. The focused test has the expected
+  result: 2 failed, 7 passed, 17 deselected. Rectangles retain widths 1/2/4;
+  at scale 2, circles currently resolve 1 to 2 and 3 to 6. Step 2 will add the
+  circle-only pixel policy.
+- Step 2 added `explicit_pixel_width` and wired only circle thickness to it.
+  Focused thickness validation is green (9 passed, 17 deselected); the full
+  render-surface module is green (26 passed); `git diff --check` passed.
+  Step 3 will perform repository-level validation without editing behavior.
+- Step 3 validation passed: 76 targeted tests passed with no skips; `make
+  check` passed (Ruff, mypy across 91 files, pytest 784 passed/21 skipped);
+  `git diff --check` passed. Main-thread review confirms only the circle
+  stroke-policy seam and its focused tests changed. No Git mutation occurred.

--- a/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/orchestration-prompt.md
+++ b/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/orchestration-prompt.md
@@ -1,0 +1,150 @@
+# Autonomous in-session implementation goal: pixel-width circle strokes
+
+## Objective
+
+Implement the approved plan so an overlay circle with `thickness=1` uses a
+one-pixel logical Qt pen at Fit/Fill scales 0.5, 1.0, and 2.0, matching the
+legacy vector line. Explicit rectangle thickness must remain viewport-scaled.
+
+This prompt is for the current in-session agent environment. Do not invoke
+Codex CLI or create an external orchestration process.
+
+## Scope and authority
+
+- Repository: `/home/jon/.local/share/EDMarketConnector/plugins/EDMCModernOverlay`
+- Approved plan: `docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/plan.md`
+- Design: `docs/plans/2026-08-29-circle-thickness-pixel-width/design/detailed-design.md`
+- Code findings: `docs/plans/2026-08-29-circle-thickness-pixel-width/research/existing-code.md`
+- Requirements: `docs/plans/2026-08-29-circle-thickness-pixel-width/idea-honing.md`
+- Governing instructions: `AGENTS.md`
+- Generated tasks: `docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/tasks/`
+- Task records: `docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/task-records/`
+- Dashboard: `docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/execution-status.md`
+
+Standing approval covers only in-scope, workspace-local source, tests,
+task artifacts, and non-destructive test/lint/type-check commands. Do not make
+network calls or external writes.
+
+### Non-negotiable Git rule
+
+**Do not commit this work.** Also do not stage, push, amend, reset, restore,
+stash, clean, checkout, switch branches, rebase, merge, or otherwise alter
+Git history or the index. Use read-only Git status/diff checks only. Preserve
+all pre-existing work exactly as found.
+
+### Scope boundary
+
+Change only circle stroke-width resolution and focused coverage. Do not change
+circle geometry/radius, Fill grouping, transform metadata, `send_shape`
+arguments, payload validation, payload inspector code, rectangle behavior,
+vector behavior, line-width configuration, or public APIs. Stop and ask the
+user if the approved plan cannot be fulfilled without a new product decision.
+
+## Start and restart recovery
+
+Before every initial run or restart:
+
+1. Read all governing and planning artifacts above.
+2. Inspect `git status --short`, `git diff --check`, the scoped diff, plan
+   checklist, task artifacts, task records, validation logs, and dashboard.
+3. Reconcile claims with filesystem evidence; resume at the first incomplete
+   or unverified task rather than trusting stale status.
+4. Update the dashboard before and after every step. Use stages `1.1`, `2.1`,
+   `2.2`, `2.3`, and `3.1`; mark a phase complete only when all its stages are
+   complete.
+
+Send a concise main-thread update before and after every task generation,
+implementation, validation, and review, plus a heartbeat at least every 60
+seconds while a subagent or long command is running. Format each update as:
+
+`Step: <number>; Task: <id>; Phase: <planning|implementation|validation>; Action: <action>; Next: <next action>.`
+
+## Isolated-context execution protocol
+
+Every code task must run in its own **fresh context window**. Never reuse a
+code-writing or validation subagent for a later task. Run worktree-writing
+agents sequentially.
+
+For each plan step, perform this exact sequence:
+
+1. Spawn one fresh `code-task-generator` subagent to create exactly one task
+   breakdown under `implementation/tasks/stepNN/`. It reads the approved plan
+   and design but makes no source or test edits.
+2. Main thread reviews that generated task for scope, target paths, test type,
+   no-commit compliance, and preservation of unrelated work.
+3. Spawn a different fresh `code-assist` subagent to execute only that reviewed
+   task. It must read the code-assist skill and write its record under
+   `implementation/task-records/stepNN-task01/`.
+4. Main thread independently reviews the diff, task handoff, command results,
+   and worktree safety before advancing.
+
+Each subagent receives only its immediate task. Its handoff must use exactly
+these headings: `Status; Files changed; Validation commands/results; Decisions;
+Risks; Next exact action.`
+
+Allow one implementation attempt and at most two remediation attempts, each in
+a new fresh context, for any task. Never rerun an unchanged failing command
+more than once. Stop with evidence after the retry limit or 20 minutes without
+substantive progress. A passing test never authorizes a commit or scope change.
+
+## Required task sequence
+
+### Step 1 — establish separate contracts
+
+Generate and execute a test-first task limited to
+`overlay_client/tests/test_render_surface_mixin.py` plus its task record.
+
+- Split the shared shape scaling assertion into rectangle and circle contracts.
+- Rectangles: `thickness=2` remains scale-aware, yielding 1, 2, and 4 at
+  scales 0.5, 1.0, and 2.0.
+- Circles: `thickness=1` must yield 1 at those scales; add a non-unit case such
+  as `thickness=3` at scale 2.0 yielding 3.
+- Run `PYQT_TESTS=1 overlay_client/.venv/bin/python -m pytest overlay_client/tests/test_render_surface_mixin.py -k thickness`.
+- The new circle assertions are expected to be red. Record that exact result
+  and do not modify production source in Step 1.
+
+### Step 2 — implement the pixel policy seam
+
+Generate and execute a fresh task limited to `overlay_client/render_surface.py`,
+`overlay_client/tests/test_render_surface_mixin.py`, and its task record.
+
+- Add a clearly named explicit pixel-width field to `_StrokeWidthSpec`; do not
+  overload the rectangle default-width field.
+- Resolve the pixel policy as a rounded, minimum-one Qt width without
+  multiplying it by `group_ctx.scale`.
+- Preserve the logical-width branch exactly for rectangles.
+- Wire only `_build_circle_command()` to pass validated circle thickness using
+  the new pixel policy.
+- Do not change geometry, grouping, transforms, payload validation, public API,
+  vector rendering, or `render_config.json`.
+- First rerun the Step 1 focused command and require green, then run the full
+  `test_render_surface_mixin.py` module with `PYQT_TESTS=1` and `git diff --check`.
+
+### Step 3 — validate integrated behavior
+
+Generate and execute a fresh validation-only task. It must not edit source or
+tests. If it finds a scoped defect, stop and request direction instead of
+fixing it during validation.
+
+Run all of these commands exactly:
+
+- `PYQT_TESTS=1 overlay_client/.venv/bin/python -m pytest overlay_client/tests/test_render_surface_mixin.py tests/test_legacy_processor.py tests/test_edmcoverlay_shapes.py`
+- `make check`
+- `git diff --check`
+- `git status --short`
+
+Review the scoped diff and confirm behavior is confined to circle stroke width
+and its tests. Report all pass, fail, and skip results exactly. A manual visual
+overlay comparison is not authorized by this prompt; list it as a follow-up.
+
+## Completion criteria and final report
+
+Report completion only when circle `thickness=1` is one pixel at all three
+scales; a non-unit circle thickness is unscaled; rectangle thickness still
+scales; focused and broad validation pass (or out-of-scope failures are proven
+and reported); `git diff --check` passes; and no prohibited Git operation
+occurred.
+
+Final report must list completed steps, changed source/test/doc files, exact
+test commands and outcomes, manual verification remaining, known limitations,
+and an explicit confirmation that no commit was made.

--- a/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/plan.md
+++ b/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/plan.md
@@ -1,0 +1,85 @@
+# Implementation plan: pixel-width circle strokes
+
+## Checklist
+
+- [x] Step 1: Prove the separate rectangle and circle contracts.
+- [x] Step 2: Add the explicit pixel-width policy and wire circles to it.
+- [x] Step 3: Run focused and repository-wide validation.
+
+## Phase status
+
+| Phase | Stage | Status |
+| --- | --- | --- |
+| 1 | 1.1 Contract tests for unscaled circles and scaled rectangles | Completed |
+| 2 | 2.1 Add and wire explicit pixel stroke policy | Completed |
+| 3 | 3.1 Focused and full validation | Completed |
+
+## Step 1: Prove the separate rectangle and circle contracts
+
+**Objective:** Replace the shared shape scaling assertion with focused tests
+that encode the intended per-shape policies before runtime behavior changes.
+
+**Guidance:** In `overlay_client/tests/test_render_surface_mixin.py`, retain
+the existing rectangle scale matrix for `thickness=2`. Add a circle scale
+matrix using `thickness=1` and expected pen width 1 at scales 0.5, 1.0, and
+2.0. Add a non-unit circle case (for example `thickness=3`, scale 2.0) with
+expected width 3. The circle assertions should initially fail under current
+production code; rectangle assertions must pass.
+
+**Tests:**
+`PYQT_TESTS=1 overlay_client/.venv/bin/python -m pytest overlay_client/tests/test_render_surface_mixin.py -k thickness`
+
+**Integration:** This establishes the public rendering contract at the
+existing `_build_circle_command()` seam without changing payload processing or
+paint commands.
+
+**Demo:** At the test level, scale 2.0 shows the distinction: rectangle
+`thickness=2` yields 4 pixels while circle `thickness=1` must yield 1.
+
+## Step 2: Add and wire explicit pixel stroke policy
+
+**Objective:** Make circles resolve supplied thickness as a stable Qt logical
+pixel width while preserving rectangle scaling.
+
+**Guidance:** Extend `_StrokeWidthSpec` with a clearly named explicit pixel
+field. In `_build_bounded_shape_command()`, resolve pixel width without the
+group scale and preserve the current clamp/copy/set-width behavior. Keep the
+logical branch intact. Change only `_build_circle_command()` to supply the
+payload thickness through the new pixel field. Do not alter geometry,
+transforms, public API validation, or line-width config.
+
+**Tests:** Rerun the focused thickness filter and then the entire
+`test_render_surface_mixin.py` module with `PYQT_TESTS=1`; both must pass.
+
+**Integration:** Circles still use the shared bounded-shape painter, so
+opacity and Qt drawing remain common. Only the width-resolution policy differs.
+
+**Demo:** On a 1920×1080 Fill overlay, a circle payload with `thickness=1`
+draws using a one-pixel Qt pen and visually matches a legacy vector whose
+`vector_line` config is 1.
+
+## Step 3: Validate no wider regression
+
+**Objective:** Verify shape ingestion, circle rendering, and the project gate
+without expanding scope.
+
+**Guidance:** Review the diff to confirm it is limited to stroke policy and
+tests. Preserve prior committed circle geometry/grouping behavior and avoid
+changing payload inspector code.
+
+**Tests:**
+
+```bash
+PYQT_TESTS=1 overlay_client/.venv/bin/python -m pytest \
+  overlay_client/tests/test_render_surface_mixin.py \
+  tests/test_legacy_processor.py \
+  tests/test_edmcoverlay_shapes.py
+make check
+git diff --check
+```
+
+**Integration:** Confirms the legacy processor’s required positive thickness,
+the circle command, and renderer remain compatible.
+
+**Demo:** Automated validation passes; manual overlay comparison shows the new
+circle ring as thin as the legacy-vector ring.

--- a/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/task-records/step01-task01/context.md
+++ b/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/task-records/step01-task01/context.md
@@ -1,0 +1,19 @@
+# Step 1 context
+
+## Scope
+
+Test-only TDD task for the approved circle stroke-width policy. Runtime source
+must remain unchanged.
+
+## Dependency map
+
+`LegacyItem` shape data flows through `_build_rect_command()` or
+`_build_circle_command()` to `_build_bounded_shape_command()`, which sets the
+Qt pen width using the injected group scale. The tests use `_StubGroupContext`
+to make the scale deterministic.
+
+## Existing pattern
+
+The pre-existing shared test parameterized both shapes. It is replaced with
+separate unit-test contracts so that rectangles retain their scale-aware
+behavior while circles describe the approved unscaled-pixel behavior.

--- a/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/task-records/step01-task01/plan.md
+++ b/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/task-records/step01-task01/plan.md
@@ -1,0 +1,11 @@
+# Step 1 test plan
+
+- Rectangle `thickness=2`: at scales 0.5, 1.0, and 2.0, assert pen widths 1,
+  2, and 4 with `MiterJoin`.
+- Circle `thickness=1`: at scales 0.5, 1.0, and 2.0, assert pen width 1 with
+  `BevelJoin`.
+- Circle `thickness=3` at scale 2.0: assert pen width 3, proving the contract
+  is unscaled for non-unit values as well.
+
+The focused thickness test is expected to fail for the circle cases until the
+separate Step 2 renderer change supplies the explicit pixel-width policy.

--- a/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/task-records/step01-task01/progress.md
+++ b/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/task-records/step01-task01/progress.md
@@ -1,0 +1,38 @@
+# Step 1 progress
+
+- [x] Read the approved design, plan, orchestration prompt, task, and governing instructions.
+- [x] Inspected the existing bounded-shape test and renderer seam.
+- [x] Replaced the shared test with separate rectangle and circle contracts.
+- [x] Run the required focused test once and record its expected RED result.
+- [x] Run `git diff --check`.
+
+## Decision
+
+The circle test uses a single three-column matrix so the three unit-width
+scales and one non-unit case share the same command-construction seam and
+join-style assertion.
+
+## Required RED evidence
+
+Command run exactly once:
+
+```text
+PYQT_TESTS=1 overlay_client/.venv/bin/python -m pytest overlay_client/tests/test_render_surface_mixin.py -k thickness
+```
+
+Result: exit 1; `2 failed, 7 passed, 17 deselected in 0.20s`.
+
+The two expected failures are both at group scale `2.0` in
+`test_explicit_circle_thickness_uses_unscaled_logical_pixels`:
+
+- `thickness=1`: actual pen width `2`, expected `1`.
+- `thickness=3`: actual pen width `6`, expected `3`.
+
+The unit-circle cases at scales `0.5` and `1.0` passed because the existing
+logical-width calculation rounds/clamps to one pixel there. The rectangle
+matrix passed, preserving its scale-aware contract.
+
+## Diff integrity
+
+`git diff --check` passed. The scoped diff contains only the intended test
+file and this task record; runtime source was not edited.

--- a/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/task-records/step02-task01/context.md
+++ b/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/task-records/step02-task01/context.md
@@ -1,0 +1,21 @@
+# Step 2 context
+
+## Scope
+
+Implement the approved circle-only stroke-width policy in the deterministic
+bounded-shape command builder. This is a unit-test-covered rendering seam; it
+does not involve EDMC lifecycle or `load.py` wiring.
+
+## Touch points and invariants
+
+- `overlay_client/render_surface.py`: add a separate caller-supplied pixel
+  policy and select it ahead of the existing logical policy.
+- Existing Step 1 tests: circles use unscaled Qt logical pixels; rectangles
+  remain scale-aware logical widths.
+- Unchanged: circle geometry, transforms, grouping, validation, vectors,
+  configuration, and public APIs.
+
+## Validation
+
+Run the focused thickness filter, the full render-surface mixin module, and
+`git diff --check` after the narrow implementation.

--- a/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/task-records/step02-task01/plan.md
+++ b/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/task-records/step02-task01/plan.md
@@ -1,0 +1,12 @@
+# Step 2 plan
+
+| Phase | Stage | Status |
+| --- | --- | --- |
+| 2 | 2.1 Add explicit pixel policy field and resolver branch | Completed |
+| 2 | 2.2 Wire circles without changing rectangle construction | Completed |
+| 2 | 2.3 Run focused/module validation and diff check | Completed |
+
+The resolver uses the separate explicit pixel field before the pre-existing
+logical field. It rounds and clamps the pixel value without applying group
+scale; malformed direct/internal values leave the copied pen unchanged rather
+than raising. Rectangles continue through their unchanged logical branch.

--- a/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/task-records/step02-task01/progress.md
+++ b/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/task-records/step02-task01/progress.md
@@ -1,0 +1,42 @@
+# Step 2 progress
+
+- [x] Read the approved design, plan, orchestration prompt, task, Step 1 red
+  evidence, and governing instructions.
+- [x] Confirmed this is a unit-test change at the bounded-shape construction
+  seam; no harness test is required.
+- [x] Added the separate explicit pixel-width policy and wired only circles to
+  it.
+- [x] Run the required focused and full module tests.
+- [x] Run `git diff --check` and review the scoped diff.
+
+## Decision
+
+`explicit_pixel_width` is separate from `default_pixel_width`: the former is a
+caller-supplied circle thickness while the latter remains a renderer default.
+The pixel branch precedes the existing logical branch, so the rect path is
+unchanged.
+
+## Git safety
+
+No Git index or history operation has been performed.
+
+## Validation evidence
+
+```text
+PYQT_TESTS=1 overlay_client/.venv/bin/python -m pytest overlay_client/tests/test_render_surface_mixin.py -k thickness
+9 passed, 17 deselected in 0.13s
+
+PYQT_TESTS=1 overlay_client/.venv/bin/python -m pytest overlay_client/tests/test_render_surface_mixin.py
+26 passed in 0.17s
+
+git diff --check
+passed (no output)
+```
+
+## Scoped-diff review
+
+The runtime diff adds only `explicit_pixel_width`, resolves it without group
+scale before the unchanged logical/default branches, and passes that policy
+only from `_build_circle_command()`. The retained Step 1 test diff separately
+proves circle pixel widths and rectangle scale-aware widths. No unrelated
+source, test, or Git-index change was made.

--- a/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/tasks/step01/task-01-prove-shape-stroke-contracts.code-task.md
+++ b/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/tasks/step01/task-01-prove-shape-stroke-contracts.code-task.md
@@ -1,0 +1,129 @@
+# Task: Prove independent rectangle and circle stroke contracts
+
+## Description
+
+Replace the shared bounded-shape thickness assertion with independent
+rectangle and circle contract tests. This establishes the intended behavior
+before production code changes: rectangle thickness remains scale-aware,
+whereas circle thickness is a stable Qt logical-pixel width.
+
+This is a deliberately test-first task. Do not change runtime source; the new
+circle assertions are expected to fail against the current renderer.
+
+## Background
+
+`_build_rect_command()` and `_build_circle_command()` both currently provide
+their explicit thickness through `_StrokeWidthSpec.explicit_logical_width`.
+The shared test consequently asserts that both shapes multiply thickness by
+the group scale. The approved design changes that contract only for circles:
+their supplied thickness must not be multiplied by the Fit/Fill scale. This
+task makes the two policies explicit without changing renderer behavior.
+
+## Reference Documentation
+
+**Required:**
+
+- Design: `docs/plans/2026-08-29-circle-thickness-pixel-width/design/detailed-design.md`
+
+**Additional References:**
+
+- Implementation plan, Step 1:
+  `docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/plan.md`
+- Existing code findings:
+  `docs/plans/2026-08-29-circle-thickness-pixel-width/research/existing-code.md`
+- Requirements decision:
+  `docs/plans/2026-08-29-circle-thickness-pixel-width/idea-honing.md`
+
+**Note:** Read the detailed design before beginning implementation. Read the
+additional references as needed for context.
+
+## Technical Requirements
+
+1. Modify only `overlay_client/tests/test_render_surface_mixin.py`; do not
+   modify runtime source in this task.
+2. Replace the current parameterized test that treats `rect` and `circle` as
+   sharing one scale policy with independent, clearly named unit-test
+   contracts at the existing command-builder seam.
+3. Preserve the rectangle matrix for `thickness=2`: group scales `0.5`,
+   `1.0`, and `2.0` must resolve to pen widths `1`, `2`, and `4`.
+4. Add a circle matrix for `thickness=1`: group scales `0.5`, `1.0`, and
+   `2.0` must each resolve to a pen width of `1`.
+5. Add a non-unit circle assertion: `thickness=3` at group scale `2.0` must
+   resolve to a pen width of `3`, proving the policy is generally unscaled.
+6. Preserve the existing join-style assertions in the appropriate separate
+   shape tests: explicit rectangles use `MiterJoin`; circles use `BevelJoin`.
+7. Select **unit tests**: the behavior is deterministic command construction
+   with an injected group context and does not depend on `load.py` or the EDMC
+   lifecycle.
+8. Run exactly:
+
+   ```bash
+   PYQT_TESTS=1 overlay_client/.venv/bin/python -m pytest overlay_client/tests/test_render_surface_mixin.py -k thickness
+   ```
+
+   The expected baseline is red because circle thickness currently scales.
+   Capture the precise failing assertions/results in the task record; do not
+   "fix" the production implementation as part of this task.
+9. Do not commit, stage, push, amend, reset, restore, stash, clean, checkout,
+   switch branches, rebase, merge, or otherwise modify Git history or index.
+   Preserve unrelated worktree changes.
+
+## Dependencies
+
+- The existing `_RectSurface`, `_CircleSurface`, `_StubGroupContext`,
+  `_build_rect_command`, and `_build_circle_command` test helpers in
+  `overlay_client/tests/test_render_surface_mixin.py`.
+- A GUI-enabled overlay-client test environment, enabled by `PYQT_TESTS=1`.
+- Step 2 will consume these intentionally red circle assertions to implement
+  the explicit pixel-width policy.
+
+## Implementation Approach
+
+1. Inspect the existing shared `test_explicit_shape_thickness_scales_with_group_context`
+   parameterization and its helpers to preserve its rectangle coverage and
+   join-style expectations.
+2. Refactor it into a rectangle-only parameterized test with the existing
+   `thickness=2` scale matrix and a circle-only parameterized test for
+   `thickness=1` with expected width one at every specified scale.
+3. Add the non-unit circle case at scale `2.0`, then run the required focused
+   command once. Record the expected red result in
+   `docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/task-records/step01-task01/`
+   when executing this task; do not change any other file or behavior.
+
+## Acceptance Criteria
+
+1. **Rectangle logical-width contract remains explicit**
+   - Given an explicit rectangle `thickness=2` and injected group scales
+     `0.5`, `1.0`, and `2.0`
+   - When `_build_rect_command()` produces its paint command
+   - Then its pen widths are `1`, `2`, and `4`, respectively, and its join is
+     `MiterJoin`.
+
+2. **Unit circle thickness is independent of scale**
+   - Given an explicit circle `thickness=1` and injected group scales `0.5`,
+     `1.0`, and `2.0`
+   - When `_build_circle_command()` produces its paint command
+   - Then each assertion requires pen width `1` and `BevelJoin`.
+
+3. **Non-unit circle thickness is independently unscaled**
+   - Given an explicit circle `thickness=3` with group scale `2.0`
+   - When `_build_circle_command()` produces its paint command
+   - Then the assertion requires pen width `3`, not `6`.
+
+4. **Red baseline proves the current mismatch**
+   - Given the new circle assertions and unmodified production renderer
+   - When the required focused `PYQT_TESTS=1` pytest command is run
+   - Then rectangle cases pass and the circle cases fail because the current
+     logical-width implementation still applies group scale.
+
+5. **Task remains behavior-safe and isolated**
+   - Given this Step 1 task is complete
+   - When its diff and Git status are reviewed
+   - Then only the focused test and its required task record are changed, with
+     no production edit and no Git index/history mutation.
+
+## Metadata
+
+- **Complexity**: Low
+- **Labels**: Rendering, Circle, Stroke Width, Unit Test, Test First
+- **Required Skills**: Python, pytest, PyQt6 command rendering tests, code-assist

--- a/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/tasks/step02/task-01-wire-circle-pixel-stroke-policy.code-task.md
+++ b/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/tasks/step02/task-01-wire-circle-pixel-stroke-policy.code-task.md
@@ -1,0 +1,113 @@
+# Task: Wire the circle pixel-stroke policy
+
+## Description
+
+Implement the approved circle-only stroke-width policy at the bounded-shape
+renderer seam. A supplied circle `thickness` must resolve as a stable Qt
+logical-pixel width, without Fit/Fill group-scale multiplication. Explicit
+rectangle thickness must continue to use its existing logical, scale-aware
+behavior.
+
+Step 1 has already established the contract in red. This task makes those
+tests green without changing circle geometry, payload validation, or other
+shape behavior.
+
+## Background
+
+Both `_build_rect_command()` and `_build_circle_command()` currently supply
+their thickness through `_StrokeWidthSpec.explicit_logical_width`.
+`_build_bounded_shape_command()` multiplies that field by `group_ctx.scale`,
+which makes a circle with `thickness=1` become a two-pixel pen at scale 1.5
+or 2.0. The legacy comparison vector treats its configured width as a Qt
+pixel width, so the approved design gives circles a distinct explicit pixel
+policy while retaining the rectangle logical policy.
+
+The existing Step 1 tests intentionally require a one-pixel circle stroke at
+scales 0.5, 1.0, and 2.0, and require a three-pixel result for a circle
+thickness of three at scale 2.0. They currently fail only where the old
+logical scaling diverges.
+
+## Reference Documentation
+
+**Required:**
+
+- Design: `docs/plans/2026-08-29-circle-thickness-pixel-width/design/detailed-design.md`
+
+**Additional References:**
+
+- Implementation plan, Step 2: `docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/plan.md`
+- Existing-code findings: `docs/plans/2026-08-29-circle-thickness-pixel-width/research/existing-code.md`
+- Requirements decision: `docs/plans/2026-08-29-circle-thickness-pixel-width/idea-honing.md`
+- Step 1 task and red evidence: `docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/tasks/step01/task-01-prove-shape-stroke-contracts.code-task.md` and `docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/task-records/step01-task01/progress.md`
+
+**Note:** You MUST read the detailed design before beginning implementation.
+Read the additional references as needed for context.
+
+## Technical Requirements
+
+1. Modify only `overlay_client/render_surface.py`, `overlay_client/tests/test_render_surface_mixin.py` when a test correction is genuinely needed, and the task record directory `docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/task-records/step02-task01/`.
+2. Add a separate, clearly named `explicit_pixel_width: Optional[float]` policy field to `_StrokeWidthSpec`. Do not overload `default_pixel_width`, which represents renderer defaults rather than a caller-supplied thickness.
+3. In `_build_bounded_shape_command()`, resolve an explicit pixel width first: round it and clamp it to at least one, without multiplying by `group_ctx.scale`. Preserve defensive no-crash behavior if a direct/internal caller supplies an unexpected non-numeric value.
+4. Preserve the current `explicit_logical_width` resolution for rectangles: `round(width * group_ctx.scale)`, clamped to at least one. Preserve the existing default-pixel fallback behavior.
+5. Change only `_build_circle_command()` to pass its already validated payload `thickness` through the new explicit pixel-width field. Keep circle color, fill, radius geometry, transforms, grouping, opacity, joins, and public `send_shape` arguments unchanged.
+6. Do not change `_build_rect_command()` semantics, vector rendering, `render_config.json`, payload processing/validation, payload inspector code, or any other public API.
+7. Use **unit tests**. The behavior is deterministic command construction with injected group context and does not depend on `load.py`, EDMC lifecycle wiring, or external services.
+8. First run the exact focused command below and require the Step 1 circle contract to become green. Then run the exact full render-surface module command and `git diff --check`. Record exact pass/fail/skip results in the Step 2 task record.
+9. Do not commit, stage, push, amend, reset, restore, stash, clean, checkout, switch branches, rebase, merge, or otherwise modify Git history or index. Preserve all pre-existing worktree changes.
+
+## Dependencies
+
+- Step 1's separate rectangle and circle contracts in `overlay_client/tests/test_render_surface_mixin.py`.
+- `_StrokeWidthSpec`, `_build_bounded_shape_command()`, `_build_rect_command()`, and `_build_circle_command()` in `overlay_client/render_surface.py`.
+- A GUI-enabled overlay-client test environment, enabled with `PYQT_TESTS=1`.
+
+## Implementation Approach
+
+1. Read the required design and Step 1 red evidence. Inspect the existing stroke policy and command-builders before editing, confirming that the shared bounded-shape path owns pen-width resolution.
+2. Extend `_StrokeWidthSpec` with the explicit pixel-width field, retaining the existing logical and default fields. In the bounded-shape resolver, select the explicit pixel policy before the logical policy and retain the existing cloned-pen and `setWidth` flow.
+3. Pass circle `thickness` as `explicit_pixel_width`; leave the rectangle construction unchanged. Keep the existing Step 1 test contracts unless a test defect is found, and add no out-of-scope coverage.
+4. Create the required Step 2 task record with the local plan, progress, exact validation evidence, scoped-diff review, and an explicit no-Git-write confirmation.
+
+## Acceptance Criteria
+
+1. **Circle thickness is an explicit pixel policy**
+   - Given a circle payload with `thickness=1` and injected group scales 0.5, 1.0, and 2.0
+   - When `_build_circle_command()` produces its paint command
+   - Then `QPen.width()` is one for every scale.
+
+2. **Non-unit circle widths remain unscaled**
+   - Given a circle payload with `thickness=3` and an injected group scale of 2.0
+   - When `_build_circle_command()` produces its paint command
+   - Then `QPen.width()` is three, not six.
+
+3. **Rectangle logical-width behavior is unchanged**
+   - Given an explicit rectangle `thickness=2` and injected group scales 0.5, 1.0, and 2.0
+   - When `_build_rect_command()` produces its paint command
+   - Then `QPen.width()` remains 1, 2, and 4 respectively, with `MiterJoin`.
+
+4. **Shared painter behavior stays intact**
+   - Given the new circle width policy
+   - When the bounded-shape command builds a stroked circle or rectangle
+   - Then it still clones the pen before applying a positive integer width, preserves the existing joins, and does not alter geometry or transforms.
+
+5. **Focused and module validation pass**
+   - Given the completed implementation
+   - When the required focused and full render-surface commands run with `PYQT_TESTS=1`
+   - Then they pass, and `git diff --check` passes.
+
+6. **Task remains isolated and reversible**
+   - Given the task is complete
+   - When the worktree and task record are reviewed
+   - Then changes are limited to the allowed source, focused test, and Step 2 task record paths; no Git index or history operation occurred.
+
+## Validation Commands
+
+- `PYQT_TESTS=1 overlay_client/.venv/bin/python -m pytest overlay_client/tests/test_render_surface_mixin.py -k thickness`
+- `PYQT_TESTS=1 overlay_client/.venv/bin/python -m pytest overlay_client/tests/test_render_surface_mixin.py`
+- `git diff --check`
+
+## Metadata
+
+- **Complexity**: Medium
+- **Labels**: Rendering, Circle, Stroke Width, Qt, Unit Test
+- **Required Skills**: Python, pytest, PyQt6 command rendering tests, code-assist

--- a/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/tasks/step03/task-01-validate-integrated-circle-stroke-policy.code-task.md
+++ b/docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/tasks/step03/task-01-validate-integrated-circle-stroke-policy.code-task.md
@@ -1,0 +1,129 @@
+# Task: Validate integrated circle pixel-stroke policy
+
+## Description
+
+Perform the approved final validation for the circle-only pixel stroke-width
+change. This is a validation-only task: it must establish that the completed
+implementation makes explicit circle thickness a stable Qt logical-pixel
+width, while explicit rectangle thickness remains group-scale-aware.
+
+Do not edit source, tests, documentation, task records, dashboard, or Git
+state. If review or validation finds a scoped defect, stop and report the
+evidence for a new implementation task; do not fix it during this task.
+
+## Background
+
+Step 1 separated the rectangle and circle width contracts. Step 2 introduced
+`_StrokeWidthSpec.explicit_pixel_width` and wired only circle thickness to it.
+The completed focused tests show that circle widths no longer multiply by the
+Fit/Fill group scale, whereas rectangle widths continue through the existing
+logical-width branch. This task validates the integration boundary without
+expanding the approved scope.
+
+## Reference Documentation
+
+**Required:**
+
+- Design: `docs/plans/2026-08-29-circle-thickness-pixel-width/design/detailed-design.md`
+
+**Additional References (if relevant to this task):**
+
+- Implementation plan, Step 3: `docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/plan.md`
+- Orchestration guardrails: `docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/orchestration-prompt.md`
+- Step 1 red evidence: `docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/task-records/step01-task01/progress.md`
+- Step 2 implementation and focused validation: `docs/plans/2026-08-29-circle-thickness-pixel-width/implementation/task-records/step02-task01/progress.md`
+
+**Note:** You MUST read the detailed design document before beginning
+validation. Read the additional references as needed for context.
+
+## Technical Requirements
+
+1. This is validation-only. Do not change any source, test, documentation,
+   task-record, dashboard, generated-task, configuration, or dependency file.
+2. Review the scoped diff before and after commands. Confirm that the only
+   behavior change is a circle-only explicit pixel-width policy and its
+   focused tests; confirm explicit rectangle thickness still uses the existing
+   group-scale-aware logical-width behavior.
+3. Confirm the diff does not alter circle geometry, radius, grouping,
+   transforms, payload validation, public `send_shape` arguments, vectors,
+   `render_config.json`, or payload-inspector behavior.
+4. Run these commands exactly, once each unless a command is interrupted by an
+   external/environmental failure:
+
+   ```bash
+   PYQT_TESTS=1 overlay_client/.venv/bin/python -m pytest overlay_client/tests/test_render_surface_mixin.py tests/test_legacy_processor.py tests/test_edmcoverlay_shapes.py
+   make check
+   git diff --check
+   git status --short
+   ```
+
+5. Report the exact command outcomes, including pass/fail/skip counts and any
+   environment limitations. Do not rerun an unchanged failing command.
+6. If a scoped defect, failed in-scope test, or scope violation is found,
+   stop immediately and report the command output/diff evidence. Do not apply
+   a correction during validation.
+7. Do not commit, stage, push, amend, reset, restore, stash, clean, checkout,
+   switch branches, rebase, merge, or otherwise alter Git history or index.
+   `git diff --check` and `git status --short` are read-only verification only.
+
+## Dependencies
+
+- The completed Step 1 circle/rectangle unit-test contracts.
+- The completed Step 2 circle-only `explicit_pixel_width` renderer policy.
+- The existing GUI-enabled overlay-client test environment, enabled with
+  `PYQT_TESTS=1`.
+
+## Implementation Approach
+
+1. Read the required design, plan, guardrails, and Step 1/2 evidence. Inspect
+   `git status --short` and the scoped diff without making any edits.
+2. Review `overlay_client/render_surface.py` and
+   `overlay_client/tests/test_render_surface_mixin.py` to verify the policy
+   split: circles use unscaled explicit pixels; rectangles retain scaled
+   explicit logical widths.
+3. Run the required validation commands exactly and record their results in
+   the execution handoff only. If all pass, report the scoped-diff review and
+   no-Git-mutation confirmation. If any scoped defect is found, stop and
+   request a new implementation task.
+
+## Acceptance Criteria
+
+1. **Circle pixel policy remains isolated**
+   - Given the scoped implementation diff
+   - When the renderer and focused tests are reviewed
+   - Then only circles supply explicit pixel widths, those widths are not
+     multiplied by group scale, and the test matrix proves widths one at
+     scales 0.5, 1.0, and 2.0 plus a non-unit unscaled case.
+
+2. **Rectangle scaling remains unchanged**
+   - Given an explicit rectangle `thickness=2` at group scales 0.5, 1.0, and
+     2.0
+   - When the focused renderer tests run
+   - Then its pen widths remain 1, 2, and 4 through the existing
+     logical-width path.
+
+3. **Integrated rendering and payload compatibility pass**
+   - Given the completed circle stroke policy
+   - When the required GUI-enabled pytest command is run
+   - Then `test_render_surface_mixin.py`, `test_legacy_processor.py`, and
+     `test_edmcoverlay_shapes.py` pass with all skip results reported.
+
+4. **Repository validation is clean**
+   - Given the scoped implementation is complete
+   - When `make check` and `git diff --check` run
+   - Then both pass, or any failure is reported with evidence and no edit is
+     made during this task.
+
+5. **Git and scope safety are preserved**
+   - Given the validation task has finished
+   - When `git status --short` and the scoped diff are reviewed
+   - Then no Git index/history operation occurred, no file was edited by this
+     task, and any pre-existing worktree changes are reported without
+     alteration.
+
+## Metadata
+
+- **Complexity**: Low
+- **Labels**: Validation, Rendering, Circle, Stroke Width, Regression
+- **Required Skills**: pytest, PyQt6 rendering tests, Git diff review,
+  code-assist

--- a/docs/plans/2026-08-29-circle-thickness-pixel-width/research/existing-code.md
+++ b/docs/plans/2026-08-29-circle-thickness-pixel-width/research/existing-code.md
@@ -1,0 +1,39 @@
+# Existing code findings
+
+## Current paint flow
+
+```mermaid
+flowchart LR
+  P[send_shape circle payload] --> L[legacy_processor]
+  L --> C[_build_circle_command]
+  C --> B[_build_bounded_shape_command]
+  B --> Q[QPen.setWidth]
+  V[Legacy vector] --> A[_QtVectorPainterAdapter.set_pen]
+  A --> Q
+```
+
+- The circle processor requires a positive integer `thickness` and stores it
+  as `LegacyItem.data["thickness"]`.
+- `_build_circle_command()` presently constructs
+  `_StrokeWidthSpec(explicit_logical_width=item.get("thickness"))`.
+- `_build_bounded_shape_command()` resolves that policy as
+  `max(1, int(round(logical_width * group_ctx.scale)))`.
+- `group_ctx.scale` is the Fit/Fill viewport scale for the legacy 1280×960
+  canvas. At 1920×1080 in Fill mode it is 1.5, making a circle thickness of 1
+  resolve to a two-pixel Qt pen.
+- The comparison legacy vector does not use that path. Its adapter takes the
+  configured `vector_line` width directly; the checked-in render config sets
+  it to 1.
+
+## Design implication
+
+The bounded-shape helper must support two explicit width policies:
+
+| Policy | Meaning | Consumer |
+| --- | --- | --- |
+| logical | multiply by Fit/Fill scale, round, minimum 1 | explicit rectangles |
+| pixel | use requested Qt logical pixel width, round, minimum 1 | explicit circles |
+
+The policy must be explicit in `_StrokeWidthSpec`; overloading the existing
+rectangle default field would blur whether a value is a supplied thickness or
+a renderer default.

--- a/docs/plans/2026-08-29-circle-thickness-pixel-width/rough-idea.md
+++ b/docs/plans/2026-08-29-circle-thickness-pixel-width/rough-idea.md
@@ -1,0 +1,6 @@
+# Circle thickness should match legacy vectors
+
+Change overlay circle payloads so `thickness=1` produces the same thin,
+one-pixel logical Qt pen used by legacy vector outlines. Circle geometry still
+scales with the legacy 1280×960 viewport; only its stroke-width policy changes.
+Rectangle thickness semantics must remain unchanged.

--- a/docs/plans/2026-08-29-circle-thickness-pixel-width/summary.md
+++ b/docs/plans/2026-08-29-circle-thickness-pixel-width/summary.md
@@ -1,0 +1,16 @@
+# Summary: pixel-width circle strokes
+
+The plan changes only circle stroke semantics: explicit circle thickness is a
+stable Qt logical-pixel width, matching legacy vector lines. Rectangle
+thickness remains viewport-scaled.
+
+Artifacts:
+
+- `rough-idea.md`
+- `idea-honing.md`
+- `research/existing-code.md`
+- `design/detailed-design.md`
+- `implementation/plan.md`
+
+No runtime or test code has changed. The next implementation step is the
+focused red/green contract work in Step 1.

--- a/docs/plans/2026-08-29-payload-inspector-circle-preview/context.md
+++ b/docs/plans/2026-08-29-payload-inspector-circle-preview/context.md
@@ -1,0 +1,28 @@
+# Payload inspector circle preview — context
+
+## Requirement
+
+Render a logged `shape: "circle"` payload in the payload inspector preview.
+
+## Existing structure and conventions
+
+- `utils/payload_inspector.py` renders selected payloads on a Tk `Canvas` using
+  the 1280×960 legacy coordinate system.
+- `_render_payload()` already renders vectors, rectangles, and messages. It
+  normalises colors and converts coordinates through the preview scale.
+- Circle payloads are emitted with `x`/`y` as centre coordinates and a positive
+  `radius`; `w` and `h` are omitted.
+- The repository uses `pytest`; this is deterministic local rendering logic, so
+  it needs a unit test rather than an EDMC harness test.
+
+## Integration map
+
+`Overlay.send_shape(circle)` → payload log → `PayloadParser` → selected
+payload → `PayloadInspectorApp._draw_preview()` → `_render_payload()` → Tk
+canvas. The missing circle dispatch is the only gap in that sequence.
+
+## Existing documentation
+
+- `README.md` describes the plugin and its Python-based cross-platform scope.
+- `docs/testing.md` describes pytest-based automated testing. No `CODEASSIST.md`
+  is present.

--- a/docs/plans/2026-08-29-payload-inspector-circle-preview/plan.md
+++ b/docs/plans/2026-08-29-payload-inspector-circle-preview/plan.md
@@ -1,0 +1,24 @@
+# Payload inspector circle preview — plan
+
+## Acceptance criteria
+
+1. Selecting a circle payload draws an oval in the inspector preview.
+2. The oval is centred at the payload `x`/`y`, and its radius is scaled from
+   the legacy 1280×960 coordinate system.
+3. Existing colour and transparent-fill handling is reused.
+4. Vectors, rectangles, and messages retain their existing rendering behavior.
+
+## Test strategy
+
+| Scenario | Input | Expected result | Test type |
+| --- | --- | --- | --- |
+| Circle geometry | circle at `(100, 200)`, radius `50`, scale `0.25`, offset `(20, 30)` | canvas receives an oval from `(32.5, 67.5)` to `(57.5, 92.5)` with the normalised styles | Unit |
+| Existing payload types | existing branches | unchanged; covered by existing behavior and scoped implementation | Regression through focused test/code review |
+
+## Implementation stages
+
+| Stage | Description | Status |
+| --- | --- | --- |
+| 1.1 | Add a focused unit test for circle canvas geometry and style | Completed |
+| 1.2 | Add circle dispatch using `create_oval` | Completed |
+| 1.3 | Run focused pytest and lint/type checks for touched files | Completed |

--- a/docs/plans/2026-08-29-payload-inspector-circle-preview/progress.md
+++ b/docs/plans/2026-08-29-payload-inspector-circle-preview/progress.md
@@ -1,0 +1,19 @@
+# Payload inspector circle preview — progress
+
+- [x] Establish implementation scope and choose unit testing.
+- [x] Document dependencies, acceptance criteria, and test strategy.
+- [x] Add failing circle-preview test (RED): failed as expected because no oval was drawn.
+- [x] Implement circle preview rendering (GREEN).
+- [x] Run focused validation: `overlay_client/.venv/bin/python -m pytest tests/test_payload_inspector.py`; `overlay_client/.venv/bin/python -m ruff check utils/payload_inspector.py tests/test_payload_inspector.py`; and `make check`.
+- [x] Commit step intentionally skipped at the user's request; changes remain uncommitted.
+
+## Validation results
+
+- Focused unit test: 1 passed.
+- Focused Ruff check: passed.
+- `make check`: Ruff passed, mypy passed for 91 files, pytest passed with 781 passed and 21 skipped.
+
+## Notes
+
+The code-assist default scratch directory is read-only in this environment, so
+these artifacts use the repository's `docs/plans/` area.

--- a/docs/plans/2026-08-30-optional-circle-thickness/implementation/code-assist/context.md
+++ b/docs/plans/2026-08-30-optional-circle-thickness/implementation/code-assist/context.md
@@ -1,0 +1,33 @@
+# Optional Circle Thickness: Context
+
+## Requirements
+
+- `circle` accepts an omitted `thickness` through both `send_shape` and raw
+  shape intake.
+- An omitted circle thickness uses the same client-controlled default as an
+  omitted rectangle: `legacy_rect`.
+- Explicit circle and rectangle thickness remain positive, logical Qt-pixel
+  widths that are not viewport/group scaled.
+- The shape gallery contains a `thickness=1` and omitted-thickness example for
+  each shape.
+- Invalid explicit circle thickness remains rejected before a same-ID item is
+  replaced.
+
+## Dependency map
+
+`EDMCOverlay.edmcoverlay.Overlay.send_shape` and raw payloads feed
+`overlay_client.legacy_processor.process_legacy_payload`, which creates a
+`LegacyItem`. `RenderSurfaceMixin._build_circle_command` and
+`_build_rect_command` resolve stored or omitted widths into Qt pens.
+`utils.shape_gallery` publishes representative payloads through the same
+legacy-overlay CLI path.
+
+## Existing patterns
+
+- Rectangles already omit `thickness` from stored data and resolve it through
+  `_line_width("legacy_rect")` at render time.
+- Both shapes use `_StrokeWidthSpec`, so the circle can reuse that same
+  fallback without changing geometry or explicit pixel-width behavior.
+- Processor tests prove validation and non-mutation; render-surface tests use
+  a pure Qt command seam; gallery tests examine generated payloads without a
+  socket.

--- a/docs/plans/2026-08-30-optional-circle-thickness/implementation/code-assist/plan.md
+++ b/docs/plans/2026-08-30-optional-circle-thickness/implementation/code-assist/plan.md
@@ -1,0 +1,35 @@
+# Optional Circle Thickness: Plan
+
+## Test strategy
+
+| Scenario | Input | Expected result |
+| --- | --- | --- |
+| Compatibility helper | `send_shape(..., shape="circle", radius=...)` | Emits no `thickness` field. |
+| Raw/client intake | Valid raw circle with omitted thickness | Normalizes, stores, and renders as a circle without an explicit thickness field. |
+| Validation regression | `None`, non-numeric, zero, or negative explicit circle thickness | Drops the update and preserves the existing item. |
+| Renderer fallback | Omitted circle thickness at scaled viewport | Uses unscaled `legacy_rect` default width. |
+| Gallery | Both shapes, explicit `1` and omitted field | Four stable, inspectable payloads. |
+
+## Implementation stages
+
+| Stage | Description | Status |
+| --- | --- | --- |
+| 1.1 | Add failing helper, processor, renderer, and gallery unit tests. | Completed |
+| 1.2 | Make circle thickness optional and use the common default at render time. | Completed |
+| 1.3 | Update generated wiki and rendering-pipeline documentation. | Completed |
+| 1.4 | Run focused tests, GUI rendering tests, and `make check`. | Completed |
+
+## Phase 2: Gallery labels
+
+| Stage | Description | Status |
+| --- | --- | --- |
+| 2.1 | Add a failing gallery test for one stable label message per shape. | Completed |
+| 2.2 | Generate descriptive, same-TTL labels above each shape. | Completed |
+| 2.3 | Run gallery tests and the project gate. | Completed |
+
+## Design decision
+
+The omitted-width default is intentionally `legacy_rect`, rather than a new
+circle-specific configuration key. It provides identical omitted-thickness
+rules for the two bounded shapes while preserving the explicit-width pixel
+contract and avoiding a preference migration.

--- a/docs/plans/2026-08-30-optional-circle-thickness/implementation/code-assist/progress.md
+++ b/docs/plans/2026-08-30-optional-circle-thickness/implementation/code-assist/progress.md
@@ -1,0 +1,23 @@
+# Optional Circle Thickness: Progress
+
+- [x] Setup: created repository-local plan artifacts after `.agents` was found
+  read-only.
+- [x] Explore: confirmed `legacy_rect` is the existing omitted-shape default.
+- [x] RED: added helper, processor, renderer, and gallery tests; all four
+  failed before implementation as expected.
+- [x] GREEN: circle thickness now omits the field end-to-end and resolves to
+  the existing `legacy_rect` default, including raw normalization.
+- [x] Documentation: updated generated wiki and pipeline contracts.
+- [x] Validation: focused GUI-enabled tests (85 passed), final `make check`
+  (ruff, mypy, 789 passed/21 skipped), and an earlier `make test` pass
+  (788 passed/21 skipped before the raw-normalization regression test was
+  added). The final `make check` includes the complete GUI-enabled suite.
+- [ ] Commit: intentionally skipped; user did not request a commit.
+
+## Phase 2: Gallery labels
+
+- [x] 2.1 RED: required a companion label payload for every gallery shape;
+  the test failed with zero labels for twelve shapes.
+- [x] 2.2 GREEN: generate descriptive labels without changing shape payloads.
+- [x] 2.3 Validation: `tests/test_shape_gallery.py` (6 passed) and final
+  `make check` (ruff, mypy, 790 passed/21 skipped).

--- a/docs/plans/2026-08-30-unify-shape-thickness-pixels/implementation/plan.md
+++ b/docs/plans/2026-08-30-unify-shape-thickness-pixels/implementation/plan.md
@@ -1,0 +1,41 @@
+# Implementation plan: unify explicit shape thickness as pixels
+
+## Scope
+
+An explicitly supplied `thickness` for either `rect` or `circle` is a logical
+Qt-pixel width, rounded and clamped to at least one pixel without viewport or
+group scaling. A rectangle that omits `thickness` continues to use the
+configured `legacy_rect` width.
+
+## Phase status
+
+| Phase | Stage | Status |
+| --- | --- | --- |
+| 1 | 1.1 Add the red rectangle pixel-width contract | Completed |
+| 2 | 2.1 Route explicit rectangles through the shared pixel policy | Completed |
+| 3 | 3.1 Validate rendering, ingestion, documentation, and repository checks | Completed |
+
+## Stages
+
+### 1.1 Contract test
+
+Replace the scale-aware explicit-rectangle matrix with an unscaled matrix:
+`thickness=2` must resolve to a 2-pixel pen at group scales 0.5, 1.0, and 2.0.
+Retain the MiterJoin assertion and omitted-rectangle default test. This is a
+pure unit test in `overlay_client/tests/test_render_surface_mixin.py`; run the
+focused thickness filter and expect red before implementation.
+
+### 2.1 Shared policy wiring
+
+Change only `_build_rect_command()` to pass explicit thickness through the
+existing `explicit_pixel_width` policy. Preserve the default-pixel fallback
+when thickness is absent, all geometry, and both shapes' existing pen/brush
+behavior. Remove the obsolete logical-width policy only if no remaining
+consumer or test needs it; otherwise do not expand the refactor.
+
+### 3.1 Validation and documentation
+
+Update the wiki-source and rendering documentation so both shapes have the
+same explicit pixel-width rule. Run the focused renderer module, legacy
+processor/API tests, `make check`, and `git diff --check`. No commit is part
+of this plan.

--- a/docs/rendering-pipeline.md
+++ b/docs/rendering-pipeline.md
@@ -31,8 +31,9 @@ This document explains how a payload travels from EDMC into the Modern Overlay c
      positive explicit logical thickness. Omitting it retains the legacy
      client-configured border width.
    - `shape:circle` → circle payload with centre coordinates, positive radius,
-     positive border thickness, fill/border data, and normal TTL/storage
-     metadata. Raw/TCP normalization retains its fields; client validation drops
+     optional positive border thickness, fill/border data, and normal TTL/storage
+     metadata. An omitted thickness uses the client-controlled `legacy_rect`
+     width. Raw/TCP normalization retains its fields; client validation drops
      invalid geometry before a same-ID drawable item can be stored or replaced.
    - `shape:vect` → vector payload with ordered points, optional markers/text. Marker label `size` accepts
      legacy presets (`small`, `normal`, `large`, `huge`); payload-level `size`/`text_size` provides the
@@ -65,7 +66,7 @@ For every legacy item, the window builds a paint command. Each builder emits inp
 
 ### Rectangles (`_build_rect_command`)
 
-1. Build pen/brush from payload colors and compute remapped rectangle corners via `remap_rect_points()`. An explicit thickness is a logical value resolved at the shared bounded-shape boundary; an omitted rectangle uses its existing pixel-width setting unchanged.
+1. Build pen/brush from payload colors and compute remapped rectangle corners via `remap_rect_points()`. An explicit thickness is a logical Qt-pixel value resolved at the shared bounded-shape boundary without viewport/group scaling; an omitted rectangle uses its existing pixel-width setting unchanged.
 2. Emit:
    - `paint:rect_input`
    - `paint:rect_output` (both overlay-space and pixel-space bounds)  
@@ -77,11 +78,12 @@ For every legacy item, the window builds a paint command. Each builder emits inp
    `x - radius` / `y - radius`; width/height are `2 * radius`.
 2. Send that square through the same legacy rectangle/group/viewport mapping as
    rectangles, including group placement, anchors, and cycle-target bounds.
-3. Build the requested border pen from `color` and `thickness`, and the fill
-   brush from `fill`; empty or `none` fill uses no brush. The shared bounded
-   shape path scales explicit logical widths with the group scale, rounds them,
-   and clamps them to one physical pixel. The shared payload opacity behaviour
-   is applied after width resolution when the command paints.
+3. Build the requested border pen from `color` and optional `thickness`, and
+   the fill brush from `fill`; empty or `none` fill uses no brush. Explicit
+   circle thickness is a logical Qt-pixel width: it is rounded and has a one
+   pixel minimum. Omitted thickness uses the client-controlled `legacy_rect`
+   width. The shared payload opacity behaviour is applied after width resolution
+   when the command paints.
 4. This path intentionally adds no `paint:circle_*` trace stage. It reuses the
    established bounded-shape mapping rather than introducing a separate circle
    trace protocol.

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -65,8 +65,8 @@ overlay.send_shape(
 ```
 # Send a circle shape
 Use `shape="circle"` for a first-class circle primitive. Its `x` and `y` are
-the centre, and `radius` and `thickness` must be positive; do not send `w` or
-`h`. 
+the centre, and `radius` must be positive; do not send `w` or `h`. An explicit
+ `thickness` must be positive and is a logical Qt-pixel border width.
 >⚠️ **Note:** `send_shape("circle"...)` is not backwards compatible - See [Developer FAQ](https://github.com/SweetJonnySauce/EDMCModernOverlay/wiki/Developer-FAQs#i-use-send_shapecircle-how-come-some-cmdrs-cannot-see-them-on-their-overlay)
 ```python
 overlay.send_shape(

--- a/docs/wiki/send_raw-API.md
+++ b/docs/wiki/send_raw-API.md
@@ -46,7 +46,7 @@ overlay.send_raw({
 | `fill` | string | Optional. Fill color for `rect` or `circle`; empty or `"none"` is transparent. |
 | `w` / `h` | integer | Optional. Width/height for `shape="rect"`. |
 | `radius` | integer | Required, strictly positive radius for `shape="circle"`. |
-| `thickness` | integer | Required, strictly positive border width for `shape="circle"`; optional, strictly positive border width for `shape="rect"`. An explicit value uses legacy-canvas units and scales with the shape. Omitting it for `rect` preserves the existing client-controlled default. |
+| `thickness` | integer | Optional, strictly positive border width for `shape="circle"` and `shape="rect"`. An explicit value is a logical Qt-pixel width. Omitting it for either shape preserves the existing client-controlled `legacy_rect` default. |
 | `vector` | array | Optional. Vector points for `shape="vect"`. |
 | `plugin` | string | Optional. Source plugin label for attribution/grouping. |
 | `command` | string | Optional. `exit` clears all; `noop` does nothing; other values are ignored. |
@@ -135,10 +135,10 @@ overlay.send_raw({
 
 Raw/TCP normalization retains supported shape thickness fields for the client.
 It does not make the geometry decision: the client warns and drops a missing,
-non-numeric, zero, or negative circle `radius`/`thickness`, or an explicitly
-supplied invalid rectangle `thickness`, before that payload can replace a
-visible same-ID shape. An omitted rectangle thickness keeps the existing client
-default.
+non-numeric, zero, or negative circle `radius`, or an explicitly supplied
+non-numeric, zero, or negative thickness for either shape, before that payload
+can replace a visible same-ID shape. Omitted thickness uses the existing
+client-controlled `legacy_rect` default.
 
 ### Example 4: Vector with marker label size
 
@@ -175,10 +175,11 @@ Clears are resolved by `id`; other fields are ignored when `text` is empty.
 
 - Messages with the same `id` replace the existing entry and refresh the TTL.
 - Empty `text` removes the message immediately.
-- A `shape="circle"` uses center `x`/`y`, positive `radius` and `thickness`, the requested `color` border, and an optional transparent `fill`. It is a shape primitive, not a `marker: "circle"` vector point.
-- Explicit `thickness` for `circle` or `rect` is a logical legacy-canvas width;
-  the renderer scales, rounds, and clamps it to at least one physical pixel.
-  Omitted rectangle thickness keeps the current client-controlled width.
+- A `shape="circle"` uses center `x`/`y`, a positive `radius`, the requested `color` border, and an optional transparent `fill`. Its `thickness` is optional. It is a shape primitive, not a `marker: "circle"` vector point.
+- Explicit circle and rectangle `thickness` are logical Qt-pixel widths; the
+  renderer rounds and clamps them to at least one pixel without viewport/group
+  scaling. Omitted thickness for either shape keeps the current
+  client-controlled `legacy_rect` width.
 - Vector payloads with insufficient points are dropped (unless a single point has `marker` or `text`).
 - Size presets are derived from the overlay font settings; adjust the "Font Step" and base font size in preferences to tune `small`/`large`/`huge`.
 - Plugin ownership is inferred from `id` prefixes (case-insensitive). If your payloads do not include a `plugin` field, add prefixes via `define_plugin_group` so the overlay can attribute payloads correctly.

--- a/docs/wiki/send_shape-API.md
+++ b/docs/wiki/send_shape-API.md
@@ -95,7 +95,7 @@ The circle form wraps and publishes this legacy payload:
 | `x` / `y` | integer | Required. Rectangle: top-left corner. Circle: center, both in the 1280x960 legacy canvas. |
 | `w` / `h` | integer | Required for `rect` only. Width/height in the 1280x960 legacy canvas. Do not send these for `circle`. |
 | `radius` | integer | Required and strictly positive for `circle`; the circle radius in legacy-canvas units. |
-| `thickness` | integer | Required and strictly positive for `circle`; optional and strictly positive for `rect`. When supplied, it is a legacy-canvas border width that scales with the shape. When omitted for `rect`, no field is sent and the existing client-controlled rectangle width is preserved. <br>⚠️ **Note:** `thickness` is not backwards compatible|
+| `thickness` | integer | Optional and strictly positive for `circle` and `rect`. An explicit value is a logical Qt-pixel border width and does not scale with the shape. When omitted, no field is sent and the existing client-controlled width is used. <br>⚠️ **Note:** `thickness` is not backwards compatible|
 | `ttl` | integer | Required. Seconds before expiry. `0` (or any value <= 0) makes the shape persistent. |
 
 If you need vector shapes (`shape="vect"`), use `send_raw` and include a `vector` list. `send_shape` does not accept vector points.
@@ -171,12 +171,13 @@ overlay.send_shape(
 - Shapes with the same `id` replace the existing entry and refresh the TTL.
 - Clear a shape by its stable `id` using the existing raw clear-by-ID behavior.
 - `fill` is transparent when empty or `"none"`; `color` requests the circle or rectangle border colour.
-- Explicit thickness is resolved after the viewport/group transform: it is scaled,
-  rounded, and clamped to at least one physical pixel. This applies to both
-  supported shapes.
-- Circle `radius` and `thickness`, and an explicitly supplied rectangle
-  `thickness`, must be numeric and strictly positive. Invalid geometry is warned
-  about and dropped by the client before it can replace a visible same-ID shape.
+- Explicit circle and rectangle thickness are resolved as logical Qt-pixel
+  widths: they are rounded and clamped to at least one pixel, but do not scale
+  with the viewport or group. Omitted thickness for either shape uses the
+  client-controlled `legacy_rect` width.
+- Circle `radius`, and any explicitly supplied circle or rectangle `thickness`,
+  must be numeric and strictly positive. Invalid geometry is warned about and
+  dropped by the client before it can replace a visible same-ID shape.
 - `rect` and `circle` are supported by `send_shape`; use `send_raw` for vectors.
 - Plugin ownership is inferred from `id` prefixes (case-insensitive). If your payloads do not include a `plugin` field, add prefixes via `define_plugin_group` so the overlay can attribute payloads correctly.
 

--- a/overlay_client/legacy_processor.py
+++ b/overlay_client/legacy_processor.py
@@ -12,7 +12,7 @@ from overlay_client.legacy_store import LegacyItem, LegacyItemStore
 LOGGER = logging.getLogger("EDMC.ModernOverlay.LegacyProcessor")
 
 _MARKER_TEXT_SIZE_CHOICES = {"small", "normal", "large", "huge"}
-_STROKE_THICKNESS_REQUIRED = {"circle": True, "rect": False}
+_STROKE_THICKNESS_SHAPES = {"circle", "rect"}
 _STROKE_THICKNESS_MISSING = object()
 
 
@@ -147,13 +147,12 @@ def _validate_shape_stroke_thickness(
     message: Mapping[str, Any],
     item_id: str,
 ) -> tuple[bool, Optional[int]]:
-    """Validate optional logical stroke width for shapes that opt in."""
+    """Validate an explicitly supplied logical stroke width for supported shapes."""
 
-    required = _STROKE_THICKNESS_REQUIRED.get(shape_name)
-    if required is None:
+    if shape_name not in _STROKE_THICKNESS_SHAPES:
         return True, None
     thickness_value = message.get("thickness", _STROKE_THICKNESS_MISSING)
-    if thickness_value is _STROKE_THICKNESS_MISSING and not required:
+    if thickness_value is _STROKE_THICKNESS_MISSING:
         return True, None
     thickness = _positive_legacy_int(thickness_value)
     if thickness is not None:
@@ -328,15 +327,15 @@ def process_legacy_payload(
                     radius_value,
                 )
                 return False
-            assert thickness is not None
             data = {
                 "color": message.get("color", "white"),
                 "fill": message.get("fill") or "#00000000",
                 "x": int(message.get("x", 0)),
                 "y": int(message.get("y", 0)),
                 "radius": radius,
-                "thickness": thickness,
             }
+            if thickness is not None:
+                data["thickness"] = thickness
             data["__mo_ttl__"] = ttl
             if trace_fn:
                 snapshot = _hashable_payload_snapshot("shape", payload)

--- a/overlay_client/payload_transform.py
+++ b/overlay_client/payload_transform.py
@@ -369,6 +369,19 @@ def accumulate_group_bounds(
             xs = [pt[0] for pt in corners]
             ys = [pt[1] for pt in corners]
             bounds.update_rect(min(xs), min(ys), max(xs), max(ys))
+        elif kind == "circle":
+            x_val = float(logical.get("x", data.get("x", 0.0)))
+            y_val = float(logical.get("y", data.get("y", 0.0)))
+            radius = float(logical.get("radius", data.get("radius", 0.0)))
+            corners = [
+                transform_point(x_val - radius, y_val - radius),
+                transform_point(x_val + radius, y_val - radius),
+                transform_point(x_val - radius, y_val + radius),
+                transform_point(x_val + radius, y_val + radius),
+            ]
+            xs = [pt[0] for pt in corners]
+            ys = [pt[1] for pt in corners]
+            bounds.update_rect(min(xs), min(ys), max(xs), max(ys))
         elif kind == "vector":
             points = logical.get("points") if isinstance(logical, Mapping) else None
             if not isinstance(points, list):

--- a/overlay_client/render_surface.py
+++ b/overlay_client/render_surface.py
@@ -116,6 +116,7 @@ class _MeasuredText:
 class _StrokeWidthSpec:
     """Internal opt-in stroke policy for bounded legacy shapes."""
 
+    explicit_pixel_width: Optional[float] = None
     explicit_logical_width: Optional[float] = None
     default_pixel_width: Optional[int] = None
 
@@ -1419,7 +1420,12 @@ class RenderSurfaceMixin:
         transform_context = group_ctx.transform_context
         scale = group_ctx.scale
         if pen.style() != Qt.PenStyle.NoPen:
-            if stroke_width.explicit_logical_width is not None:
+            if stroke_width.explicit_pixel_width is not None:
+                try:
+                    resolved_width = max(1, int(round(float(stroke_width.explicit_pixel_width))))
+                except (TypeError, ValueError, OverflowError):
+                    resolved_width = None
+            elif stroke_width.explicit_logical_width is not None:
                 resolved_width = max(1, int(round(stroke_width.explicit_logical_width * scale)))
             else:
                 resolved_width = stroke_width.default_pixel_width
@@ -1623,7 +1629,7 @@ class RenderSurfaceMixin:
             kind="circle",
             pen=pen,
             brush=brush,
-            stroke_width=_StrokeWidthSpec(explicit_logical_width=item.get("thickness")),
+            stroke_width=_StrokeWidthSpec(explicit_pixel_width=item.get("thickness")),
             raw_x=raw_x,
             raw_y=raw_y,
             raw_w=diameter,

--- a/overlay_client/render_surface.py
+++ b/overlay_client/render_surface.py
@@ -117,7 +117,6 @@ class _StrokeWidthSpec:
     """Internal opt-in stroke policy for bounded legacy shapes."""
 
     explicit_pixel_width: Optional[float] = None
-    explicit_logical_width: Optional[float] = None
     default_pixel_width: Optional[int] = None
 
 
@@ -1425,8 +1424,6 @@ class RenderSurfaceMixin:
                     resolved_width = max(1, int(round(float(stroke_width.explicit_pixel_width))))
                 except (TypeError, ValueError, OverflowError):
                     resolved_width = None
-            elif stroke_width.explicit_logical_width is not None:
-                resolved_width = max(1, int(round(stroke_width.explicit_logical_width * scale)))
             else:
                 resolved_width = stroke_width.default_pixel_width
             if resolved_width is not None:
@@ -1578,7 +1575,7 @@ class RenderSurfaceMixin:
             pen=pen,
             brush=brush,
             stroke_width=_StrokeWidthSpec(
-                explicit_logical_width=item.get("thickness"),
+                explicit_pixel_width=item.get("thickness"),
                 default_pixel_width=None if "thickness" in item else self._line_width("legacy_rect"),
             ),
             raw_x=float(item.get("x", 0)),
@@ -1629,7 +1626,10 @@ class RenderSurfaceMixin:
             kind="circle",
             pen=pen,
             brush=brush,
-            stroke_width=_StrokeWidthSpec(explicit_pixel_width=item.get("thickness")),
+            stroke_width=_StrokeWidthSpec(
+                explicit_pixel_width=item.get("thickness"),
+                default_pixel_width=None if "thickness" in item else self._line_width("legacy_rect"),
+            ),
             raw_x=raw_x,
             raw_y=raw_y,
             raw_w=diameter,

--- a/overlay_client/tests/test_payload_bounds.py
+++ b/overlay_client/tests/test_payload_bounds.py
@@ -85,6 +85,64 @@ def test_message_bounds_fill_mode_uses_text_measurements(monkeypatch) -> None:
     assert (bounds.max_y - bounds.min_y) == pytest.approx(fake_height)
 
 
+def test_circle_bounds_cover_full_radius() -> None:
+    bounds = GroupBounds()
+    item = LegacyItem(
+        item_id="circle",
+        kind="circle",
+        data={"x": 100, "y": 200, "radius": 25},
+        expiry=None,
+        plugin="test",
+    )
+
+    payload_transform.accumulate_group_bounds(
+        bounds,
+        item,
+        pixels_per_overlay_unit=1.0,
+        font_family="Eurostile",
+        preset_point_size=lambda _label: 12.0,
+    )
+
+    assert bounds.is_valid()
+    assert bounds.min_x == pytest.approx(75.0)
+    assert bounds.min_y == pytest.approx(175.0)
+    assert bounds.max_x == pytest.approx(125.0)
+    assert bounds.max_y == pytest.approx(225.0)
+
+
+def test_circle_bounds_transform_full_radius() -> None:
+    bounds = GroupBounds()
+    item = LegacyItem(
+        item_id="circle",
+        kind="circle",
+        data={
+            "x": 100,
+            "y": 200,
+            "radius": 25,
+            "__mo_transform__": {
+                "scale": {"x": 2.0, "y": 0.5},
+                "offset": {"x": 10.0, "y": -20.0},
+            },
+        },
+        expiry=None,
+        plugin="test",
+    )
+
+    payload_transform.accumulate_group_bounds(
+        bounds,
+        item,
+        pixels_per_overlay_unit=1.0,
+        font_family="Eurostile",
+        preset_point_size=lambda _label: 12.0,
+    )
+
+    assert bounds.is_valid()
+    assert bounds.min_x == pytest.approx(160.0)
+    assert bounds.min_y == pytest.approx(67.5)
+    assert bounds.max_x == pytest.approx(260.0)
+    assert bounds.max_y == pytest.approx(92.5)
+
+
 def test_overlay_bounds_dataclass_tracks_min_max() -> None:
     bounds = _OverlayBounds()
     bounds.include_rect(10.0, 20.0, 30.0, 60.0)

--- a/overlay_client/tests/test_render_surface_mixin.py
+++ b/overlay_client/tests/test_render_surface_mixin.py
@@ -382,8 +382,8 @@ def test_rect_command_valid_border_color_uses_pen(monkeypatch: pytest.MonkeyPatc
     assert cmd.pen.width() == surface._line_width("legacy_rect")
 
 
-@pytest.mark.parametrize(("scale", "expected_width"), [(0.5, 1), (1.0, 2), (2.0, 4)])
-def test_explicit_rect_thickness_scales_with_group_context(
+@pytest.mark.parametrize(("scale", "expected_width"), [(0.5, 2), (1.0, 2), (2.0, 2)])
+def test_explicit_rect_thickness_uses_unscaled_logical_pixels(
     monkeypatch: pytest.MonkeyPatch,
     scale: float,
     expected_width: int,
@@ -431,6 +431,18 @@ def test_omitted_rect_thickness_keeps_unscaled_legacy_default(monkeypatch: pytes
     assert cmd.pen.width() == surface._line_width("legacy_rect")
 
 
+def test_omitted_circle_thickness_keeps_unscaled_legacy_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    surface = _CircleSurface()
+    monkeypatch.setattr(
+        "overlay_client.render_surface.build_group_context",
+        lambda *args, **kwargs: _StubGroupContext(scale=2.0),
+    )
+
+    cmd = _build_circle_command(surface, thickness=None)
+
+    assert cmd.pen.width() == surface._line_width("legacy_rect")
+
+
 def test_explicit_rect_thickness_uses_miter_join_without_changing_legacy_join(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -466,7 +478,7 @@ def test_explicit_stroke_resolution_copies_the_source_pen(monkeypatch: pytest.Mo
         kind="rect",
         pen=source_pen,
         brush=QBrush(Qt.BrushStyle.NoBrush),
-        stroke_width=_StrokeWidthSpec(explicit_logical_width=2),
+        stroke_width=_StrokeWidthSpec(explicit_pixel_width=2),
         raw_x=1,
         raw_y=2,
         raw_w=3,
@@ -475,7 +487,7 @@ def test_explicit_stroke_resolution_copies_the_source_pen(monkeypatch: pytest.Mo
 
     assert source_pen.width() == 9
     assert cmd.pen is not source_pen
-    assert cmd.pen.width() == 4
+    assert cmd.pen.width() == 2
 
 
 def _build_circle_command(
@@ -484,19 +496,21 @@ def _build_circle_command(
     border_spec: str = "#ff00ff",
     fill_spec: str = "#112233",
     group_transform=None,
-    thickness: float = 5.0,
+    thickness: Optional[float] = 5.0,
 ):
+    data = {
+        "color": border_spec,
+        "fill": fill_spec,
+        "x": 10.0,
+        "y": 20.0,
+        "radius": 3.0,
+    }
+    if thickness is not None:
+        data["thickness"] = thickness
     legacy_item = LegacyItem(
         item_id="circle-1",
         kind="circle",
-        data={
-            "color": border_spec,
-            "fill": fill_spec,
-            "x": 10.0,
-            "y": 20.0,
-            "radius": 3.0,
-            "thickness": thickness,
-        },
+        data=data,
         plugin="plugin",
     )
     return surface._build_circle_command(legacy_item, _RectStubMapper(), GroupKey("plugin"), group_transform, None)

--- a/overlay_client/tests/test_render_surface_mixin.py
+++ b/overlay_client/tests/test_render_surface_mixin.py
@@ -383,12 +383,29 @@ def test_rect_command_valid_border_color_uses_pen(monkeypatch: pytest.MonkeyPatc
 
 
 @pytest.mark.parametrize(("scale", "expected_width"), [(0.5, 1), (1.0, 2), (2.0, 4)])
-@pytest.mark.parametrize("shape", ["rect", "circle"])
-def test_explicit_shape_thickness_scales_with_group_context(
+def test_explicit_rect_thickness_scales_with_group_context(
     monkeypatch: pytest.MonkeyPatch,
     scale: float,
     expected_width: int,
-    shape: str,
+) -> None:
+    surface = _RectSurface()
+    monkeypatch.setattr(
+        "overlay_client.render_surface.build_group_context",
+        lambda *args, **kwargs: _StubGroupContext(scale=scale),
+    )
+
+    cmd = _build_rect_command(surface, "#ff00ff", thickness=2)
+
+    assert cmd.pen.width() == expected_width
+    assert cmd.pen.joinStyle() == Qt.PenJoinStyle.MiterJoin
+
+
+@pytest.mark.parametrize(("scale", "thickness", "expected_width"), [(0.5, 1, 1), (1.0, 1, 1), (2.0, 1, 1), (2.0, 3, 3)])
+def test_explicit_circle_thickness_uses_unscaled_logical_pixels(
+    monkeypatch: pytest.MonkeyPatch,
+    scale: float,
+    thickness: float,
+    expected_width: int,
 ) -> None:
     surface = _CircleSurface()
     monkeypatch.setattr(
@@ -396,14 +413,10 @@ def test_explicit_shape_thickness_scales_with_group_context(
         lambda *args, **kwargs: _StubGroupContext(scale=scale),
     )
 
-    if shape == "rect":
-        cmd = _build_rect_command(surface, "#ff00ff", thickness=2)
-    else:
-        cmd = _build_circle_command(surface, thickness=2)
+    cmd = _build_circle_command(surface, thickness=thickness)
 
     assert cmd.pen.width() == expected_width
-    expected_join = Qt.PenJoinStyle.MiterJoin if shape == "rect" else Qt.PenJoinStyle.BevelJoin
-    assert cmd.pen.joinStyle() == expected_join
+    assert cmd.pen.joinStyle() == Qt.PenJoinStyle.BevelJoin
 
 
 def test_omitted_rect_thickness_keeps_unscaled_legacy_default(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_edmcoverlay_shapes.py
+++ b/tests/test_edmcoverlay_shapes.py
@@ -53,6 +53,21 @@ def test_send_shape_circle_preserves_stable_id_and_ttl(monkeypatch):
     ]
 
 
+def test_send_shape_omits_unset_circle_thickness(monkeypatch):
+    published = []
+    monkeypatch.setattr(edmcoverlay, "send_overlay_message", lambda payload: published.append(payload) or True)
+
+    edmcoverlay.Overlay().send_shape(
+        "default-circle",
+        "circle",
+        x=100,
+        y=200,
+        radius=50,
+    )
+
+    assert "thickness" not in published[-1]
+
+
 def test_send_shape_preserves_positional_rectangle_payload(monkeypatch):
     published = []
     monkeypatch.setattr(edmcoverlay, "send_overlay_message", lambda payload: published.append(payload) or True)
@@ -129,28 +144,33 @@ def test_normalise_raw_circle_preserves_canonical_geometry_and_metadata():
 
 
 @pytest.mark.parametrize(
-    ("message", "radius", "thickness"),
+    ("message", "radius", "thickness", "has_thickness"),
     [
         (
             {"Shape": "circle", "Id": "circle-alias", "Radius": "invalid", "Thickness": -2},
             "invalid",
             -2,
+            True,
         ),
         (
             {"shape": "circle", "id": "circle-zero", "radius": 0, "thickness": 0},
             0,
             0,
+            True,
         ),
-        ({"shape": "circle", "id": "circle-missing"}, None, None),
+        ({"shape": "circle", "id": "circle-missing"}, None, None, False),
     ],
 )
-def test_normalise_raw_circle_preserves_aliased_and_invalid_geometry(message, radius, thickness):
+def test_normalise_raw_circle_preserves_aliased_and_invalid_geometry(message, radius, thickness, has_thickness):
     payload = edmcoverlay.normalise_legacy_payload(message)
 
     assert payload is not None
     assert payload["type"] == "shape"
     assert payload["radius"] == radius
-    assert payload["thickness"] == thickness
+    if has_thickness:
+        assert payload["thickness"] == thickness
+    else:
+        assert "thickness" not in payload
 
 
 def test_normalise_raw_rectangle_and_vector_contracts_are_unchanged():

--- a/tests/test_legacy_processor.py
+++ b/tests/test_legacy_processor.py
@@ -86,6 +86,52 @@ def test_process_rect_payload_preserves_valid_explicit_thickness():
     assert item.data["thickness"] == 3
 
 
+def test_process_circle_payload_allows_omitted_thickness():
+    store = LegacyItemStore()
+
+    changed = process_legacy_payload(
+        store,
+        {
+            "type": "shape",
+            "shape": "circle",
+            "id": "circle-default-width",
+            "color": "#abcdef",
+            "fill": "#112233",
+            "x": 5,
+            "y": 6,
+            "radius": 40,
+            "ttl": 3,
+        },
+    )
+
+    assert changed is True
+    item = store.get("circle-default-width")
+    assert item is not None
+    assert item.kind == "circle"
+    assert "thickness" not in item.data
+
+
+def test_process_normalised_raw_circle_allows_omitted_thickness():
+    store = LegacyItemStore()
+    payload = normalise_legacy_payload(
+        {
+            "shape": "circle",
+            "id": "raw-circle-default-width",
+            "x": 5,
+            "y": 6,
+            "radius": 40,
+            "ttl": 3,
+        },
+    )
+
+    assert payload is not None
+    assert "thickness" not in payload
+    assert process_legacy_payload(store, payload) is True
+    item = store.get("raw-circle-default-width")
+    assert item is not None
+    assert "thickness" not in item.data
+
+
 @pytest.mark.parametrize("invalid_thickness", [None, "not-a-number", 0, -1])
 def test_invalid_explicit_rect_thickness_warns_and_preserves_existing_item(
     caplog: pytest.LogCaptureFixture,
@@ -347,7 +393,7 @@ def test_circle_zero_ttl_uses_existing_next_purge_contract(monkeypatch: pytest.M
         ("radius", "not-a-number", False),
         ("radius", 0, False),
         ("radius", -1, False),
-        ("thickness", None, True),
+        ("thickness", None, False),
         ("thickness", "not-a-number", False),
         ("thickness", 0, False),
         ("thickness", -1, False),
@@ -388,7 +434,7 @@ def test_invalid_circle_geometry_warns_and_preserves_existing_item(
         ("radius", "not-a-number", False),
         ("radius", 0, False),
         ("radius", -1, False),
-        ("thickness", None, True),
+        ("thickness", None, False),
         ("thickness", "not-a-number", False),
         ("thickness", 0, False),
         ("thickness", -1, False),

--- a/tests/test_payload_inspector.py
+++ b/tests/test_payload_inspector.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any
+
+from utils.payload_inspector import PayloadInspectorApp
+
+
+class _Canvas:
+    def __init__(self) -> None:
+        self.ovals: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def create_oval(self, *args: Any, **kwargs: Any) -> None:
+        self.ovals.append((args, kwargs))
+
+
+def test_circle_payload_preview_draws_scaled_oval() -> None:
+    canvas = _Canvas()
+    app = PayloadInspectorApp.__new__(PayloadInspectorApp)
+
+    app._render_payload(
+        canvas,
+        {
+            "type": "shape",
+            "shape": "circle",
+            "color": "#80d0ff",
+            "fill": "none",
+            "x": 100,
+            "y": 200,
+            "radius": 50,
+            "thickness": 2,
+        },
+        offset_x=20,
+        offset_y=30,
+        scale=0.25,
+    )
+
+    assert canvas.ovals == [
+        (
+            (32.5, 67.5, 57.5, 92.5),
+            {"outline": "#80d0ff", "width": 2, "fill": ""},
+        )
+    ]

--- a/tests/test_shape_gallery.py
+++ b/tests/test_shape_gallery.py
@@ -7,21 +7,23 @@ from utils import shape_gallery
 
 def test_shape_gallery_covers_visual_variations_with_requested_ttl() -> None:
     payloads = shape_gallery.build_gallery_payloads(ttl=17)
+    shapes = [payload for payload in payloads if payload["type"] == "shape"]
 
     assert payloads
-    assert {payload["shape"] for payload in payloads} == {"circle", "rect"}
-    assert all(payload["type"] == "shape" for payload in payloads)
+    assert {payload["shape"] for payload in shapes} == {"circle", "rect"}
     assert all(payload["id"].startswith("shape-gallery-") for payload in payloads)
     assert {payload["ttl"] for payload in payloads} == {17}
 
-    circles = [payload for payload in payloads if payload["shape"] == "circle"]
-    rectangles = [payload for payload in payloads if payload["shape"] == "rect"]
+    circles = [payload for payload in shapes if payload["shape"] == "circle"]
+    rectangles = [payload for payload in shapes if payload["shape"] == "rect"]
     assert all("radius" in payload and "w" not in payload and "h" not in payload for payload in circles)
     assert all("w" in payload and "h" in payload for payload in rectangles)
-    assert {payload["fill"] for payload in payloads} >= {"none", "#1a1a1a"}
-    assert len({payload["color"] for payload in payloads}) >= 4
-    assert len({payload["thickness"] for payload in payloads}) >= 3
-    assert len({(payload.get("radius"), payload.get("w"), payload.get("h")) for payload in payloads}) >= 4
+    assert {payload["fill"] for payload in shapes} >= {"none", "#1a1a1a"}
+    assert len({payload["color"] for payload in shapes}) >= 4
+    explicit_thicknesses = {payload["thickness"] for payload in shapes if "thickness" in payload}
+    assert len(explicit_thicknesses) >= 3
+    assert any("thickness" not in payload for payload in shapes)
+    assert len({(payload.get("radius"), payload.get("w"), payload.get("h")) for payload in shapes}) >= 4
 
 
 def test_shape_gallery_includes_concentric_outline_circles_and_solid_fills() -> None:
@@ -34,8 +36,34 @@ def test_shape_gallery_includes_concentric_outline_circles_and_solid_fills() -> 
     assert all(payload["fill"] == "none" for payload in concentric)
     assert len({payload["color"] for payload in concentric}) == 3
 
-    solid_fills = [payload for payload in payloads if payload["fill"] in {"#1a1a1a", "#102a3a", "#163a16"}]
+    solid_fills = [payload for payload in payloads if payload.get("fill") in {"#1a1a1a", "#102a3a", "#163a16"}]
     assert len(solid_fills) == 3
+
+
+def test_shape_gallery_includes_explicit_and_default_width_examples_for_each_shape() -> None:
+    payloads_by_id = {payload["id"]: payload for payload in shape_gallery.build_gallery_payloads()}
+
+    for shape in ("rect", "circle"):
+        thin = payloads_by_id[f"shape-gallery-{shape}-thin-outline"]
+        default_width = payloads_by_id[f"shape-gallery-{shape}-default-outline"]
+        assert thin["shape"] == default_width["shape"] == shape
+        assert thin["thickness"] == 1
+        assert "thickness" not in default_width
+
+
+def test_shape_gallery_labels_each_shape_with_its_variant_and_width_mode() -> None:
+    payloads = shape_gallery.build_gallery_payloads(ttl=17)
+    shapes = [payload for payload in payloads if payload["type"] == "shape"]
+    labels_by_id = {payload["id"]: payload for payload in payloads if payload["type"] == "message"}
+
+    assert len(labels_by_id) == len(shapes)
+    for shape in shapes:
+        label = labels_by_id[f"shape-gallery-label-{shape['id'].removeprefix('shape-gallery-')}"]
+        assert label["ttl"] == shape["ttl"]
+        assert label["size"] == "small"
+        assert label["text"].startswith("Rectangle:" if shape["shape"] == "rect" else "Circle:")
+        expected_width = f"thickness={shape['thickness']}" if "thickness" in shape else "default thickness"
+        assert expected_width in label["text"]
 
 
 def test_shape_gallery_supports_persistent_payloads() -> None:

--- a/utils/payload_inspector.py
+++ b/utils/payload_inspector.py
@@ -1061,6 +1061,21 @@ class PayloadInspectorApp:
                     width=2,
                     smooth=True,
                 )
+        elif shape == "circle":
+            radius = _coerce_number(data.get("radius"))
+            if radius > 0:
+                center_x = offset_x + (x or 0) * scale
+                center_y = offset_y + (y or 0) * scale
+                scaled_radius = radius * scale
+                canvas.create_oval(
+                    center_x - scaled_radius,
+                    center_y - scaled_radius,
+                    center_x + scaled_radius,
+                    center_y + scaled_radius,
+                    outline=color if self._is_valid_color(color) else "#80d0ff",
+                    width=2,
+                    fill=fill_color if self._is_valid_color(fill_color) else "",
+                )
         elif shape == "rect" or shape == "message" or text:
             box_w = max(10, (w or 0) * scale)
             box_h = max(10, (h or 0) * scale)

--- a/utils/shape_gallery.py
+++ b/utils/shape_gallery.py
@@ -18,10 +18,37 @@ DEFAULT_TTL_SECONDS = 60
 DEFAULT_TIMEOUT_SECONDS = 5.0
 
 
+def _shape_label_payload(shape: Mapping[str, Any]) -> Dict[str, Any]:
+    """Describe one gallery shape immediately above its bounding box."""
+
+    shape_name = str(shape["shape"])
+    label_name = "Rectangle" if shape_name == "rect" else "Circle"
+    variant = str(shape["id"]).removeprefix(f"shape-gallery-{shape_name}-").replace("-", " ")
+    width = f"thickness={shape['thickness']}" if "thickness" in shape else "default thickness"
+    if shape_name == "rect":
+        label_x = int(shape["x"])
+        label_y = max(0, int(shape["y"]) - 18)
+    else:
+        radius = int(shape["radius"])
+        label_x = int(shape["x"]) - radius
+        label_y = max(0, int(shape["y"]) - radius - 18)
+    variant_id = str(shape["id"]).removeprefix("shape-gallery-")
+    return {
+        "type": "message",
+        "id": f"shape-gallery-label-{variant_id}",
+        "text": f"{label_name}: {variant} ({width})",
+        "color": shape["color"],
+        "x": label_x,
+        "y": label_y,
+        "size": "small",
+        "ttl": shape["ttl"],
+    }
+
+
 def build_gallery_payloads(ttl: int = DEFAULT_TTL_SECONDS) -> List[Dict[str, Any]]:
     """Return a stable gallery that exercises shape appearance variations."""
 
-    return [
+    shapes = [
         {
             "type": "shape",
             "shape": "rect",
@@ -46,6 +73,18 @@ def build_gallery_payloads(ttl: int = DEFAULT_TTL_SECONDS) -> List[Dict[str, Any
             "w": 380,
             "h": 180,
             "thickness": 6,
+            "ttl": ttl,
+        },
+        {
+            "type": "shape",
+            "shape": "rect",
+            "id": "shape-gallery-rect-default-outline",
+            "color": "#ffd166",
+            "fill": "none",
+            "x": 60,
+            "y": 260,
+            "w": 250,
+            "h": 100,
             "ttl": ttl,
         },
         {
@@ -83,6 +122,17 @@ def build_gallery_payloads(ttl: int = DEFAULT_TTL_SECONDS) -> List[Dict[str, Any
             "y": 440,
             "radius": 110,
             "thickness": 4,
+            "ttl": ttl,
+        },
+        {
+            "type": "shape",
+            "shape": "circle",
+            "id": "shape-gallery-circle-default-outline",
+            "color": "#ffd166",
+            "fill": "none",
+            "x": 180,
+            "y": 680,
+            "radius": 50,
             "ttl": ttl,
         },
         {
@@ -146,6 +196,7 @@ def build_gallery_payloads(ttl: int = DEFAULT_TTL_SECONDS) -> List[Dict[str, Any
             "ttl": ttl,
         },
     ]
+    return [*shapes, *(_shape_label_payload(shape) for shape in shapes)]
 
 
 def _read_port(port_file: Path) -> int:

--- a/version.py
+++ b/version.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 __all__ = ["__version__", "is_dev_build", "DEV_MODE_ENV_VAR"]
 
-__version__ = "0.9.0"
+__version__ = "0.9.2"
 DEV_MODE_ENV_VAR = "MODERN_OVERLAY_DEV_MODE"
 
 


### PR DESCRIPTION
1. bumped version to 0.9.2
2. Fixed circle grouping issue. Grouping logic now take full circle into consideration based on x/y and r
3. Changed thickness to pixel width
